### PR TITLE
fix: take the LeafIndex change from mmr v0.0.9

### DIFF
--- a/eventdiag.go
+++ b/eventdiag.go
@@ -170,7 +170,7 @@ func NewEventDiagCmd() *cli.Command {
 					return err
 				}
 
-				leafIndex := mmr.LeafCount(mmrIndex)
+				leafIndex := mmr.LeafIndex(mmrIndex)
 				// Note that the banner info is all from the event response
 				fmt.Printf("%d %s %s\n", leafIndex, time.UnixMilli(respIDTimeMS).Format(time.RFC3339Nano), resp.Identity)
 

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.22
 require (
 	github.com/datatrails/go-datatrails-common v0.16.1
 	github.com/datatrails/go-datatrails-common-api-gen v0.4.6
-	github.com/datatrails/go-datatrails-merklelog/massifs v0.0.4
-	github.com/datatrails/go-datatrails-merklelog/mmr v0.0.1
+	github.com/datatrails/go-datatrails-merklelog/massifs v0.0.9
+	github.com/datatrails/go-datatrails-merklelog/mmr v0.0.2
 	github.com/datatrails/go-datatrails-merklelog/mmrtesting v0.0.1
 	github.com/datatrails/go-datatrails-simplehash v0.0.3
 	github.com/urfave/cli/v2 v2.27.1

--- a/go.sum
+++ b/go.sum
@@ -47,10 +47,10 @@ github.com/datatrails/go-datatrails-common v0.16.1 h1:kaNOwyu8EmBbIR44daWDiUZxBt
 github.com/datatrails/go-datatrails-common v0.16.1/go.mod h1:IEcuwUaFl+bI1tt30r+Ov2+nvpcAZH/kXmAPGFjkwT4=
 github.com/datatrails/go-datatrails-common-api-gen v0.4.6 h1:yzviWC2jBOC3ItotQQlWKmMvqpFJXOkuBdU0ml84Fjg=
 github.com/datatrails/go-datatrails-common-api-gen v0.4.6/go.mod h1:OQN91xvlW6xcWTFvwsM2Nn4PZwFAIOE52FG7yRl4QPQ=
-github.com/datatrails/go-datatrails-merklelog/massifs v0.0.4 h1:N5sfzROBeoEuHoJtLSfR5enBYi51aSOpPRSoT6YXrfo=
-github.com/datatrails/go-datatrails-merklelog/massifs v0.0.4/go.mod h1:9gVKGJXWmQru2TlWF7Ho+jVCQRJTZKoT2L7Lda1batI=
-github.com/datatrails/go-datatrails-merklelog/mmr v0.0.1 h1:XggMVejsJ72cAL/msjPhQUSQNeElSh/O1zZcvX4d4JU=
-github.com/datatrails/go-datatrails-merklelog/mmr v0.0.1/go.mod h1:+Oz8O6bns0rF6gr03xJzKTBzUzyskZ8Gics8/qeNzYk=
+github.com/datatrails/go-datatrails-merklelog/massifs v0.0.9 h1:89ma+ZM2UllHdBGOzjye8MXiizpJWZbCthhESyO84tY=
+github.com/datatrails/go-datatrails-merklelog/massifs v0.0.9/go.mod h1:5o8k+btUoxenGw9sy7x85q2qdzsmu9v2ALMk13RTpG4=
+github.com/datatrails/go-datatrails-merklelog/mmr v0.0.2 h1:Jxov4/onoFiCISLQNSPy/nyt3USAEvUZpEjlScHJYKI=
+github.com/datatrails/go-datatrails-merklelog/mmr v0.0.2/go.mod h1:+Oz8O6bns0rF6gr03xJzKTBzUzyskZ8Gics8/qeNzYk=
 github.com/datatrails/go-datatrails-merklelog/mmrtesting v0.0.1 h1:sIyXWKTadqmVEsPj66RlKwRKzNQ7hK9SH1fRjZFDCa8=
 github.com/datatrails/go-datatrails-merklelog/mmrtesting v0.0.1/go.mod h1:KGdkOtamWG48EN4AXtTHPv6C0jJKrj840IMSkrD+egk=
 github.com/datatrails/go-datatrails-simplehash v0.0.3 h1:H4zNsdB9d2KMZ3EqM6n6AMGYB/RquEjANqcNrUlZtp8=


### PR DESCRIPTION
AB#9551

unit and integration test output:

banks:veracity robin$ ta codequality:all
Linting: .
golangci-lint has version 1.56.2 built with go1.22.0 from 58a724a0 on 2024-02-15T18:01:51Z
banks:veracity robin$ ta gotest:go:unit
{"type":"output","data":"\tgithub.com/datatrails/veracity/cmd/veracity\t\tcoverage: 0.0% of statements"}
{"type":"output","data":"\tgithub.com/datatrails/veracity/veracitytesting\t\tcoverage: 0.0% of statements"}
{"type":"output","data":"\tgithub.com/datatrails/veracity\t\tcoverage: 0.0% of statements"}
banks:veracity robin$ ta gotest:go:azurite
{"type":"output","data":"\tgithub.com/datatrails/veracity/cmd/veracity\t\tcoverage: 0.0% of statements"}
{"type":"output","data":"\tgithub.com/datatrails/veracity/veracitytesting\t\tcoverage: 0.0% of statements"}
{"type":"run_test","name":"TestNodeCmd"}
{"type":"output","data":"{\"level\":\"info\",\"ts\":1717584917.818381,\"caller\":\"veracity/node_test.go:29\",\"msg\":\"url: ''\"}"}
{"type":"run_test","name":"TestNodeCmd/\u003cprogname\u003e_-s_devstoreaccount1_-c_testnodecmd_-t_tenant/0684984b-654d-4301-ad10-a508126e187d_node_1"}
{"type":"output","data":"4884a1ccd11a710cb14a315afe4b7742790bab68004938e9e95d693f3ada59e5"}
{"type":"end_test","name":"TestNodeCmd","result":"PASS","duration":500000000}
{"type":"end_test","name":"TestNodeCmd/\u003cprogname\u003e_-s_devstoreaccount1_-c_testnodecmd_-t_tenant/0684984b-654d-4301-ad10-a508126e187d_node_1","result":"PASS","duration":120000000,"indent":1}
{"type":"run_test","name":"TestNodeScanCmd"}
{"type":"output","data":"{\"level\":\"info\",\"ts\":1717584918.321198,\"caller\":\"veracity/nodescan_test.go:30\",\"msg\":\"url: ''\"}"}
{"type":"output","data":"TreeIndex(7) == 11"}
{"type":"run_test","name":"TestNodeScanCmd/\u003cprogname\u003e_-s_devstoreaccount1_-c_testnodescancmd_-t_tenant/0684984b-654d-4301-ad10-a508126e187d_nodescan_-m_0_-v_d7918c89c44bd508eb645fc4448abf89a8ebf63142b05801a65d590a05ad814b"}
{"type":"output","data":"11"}
{"type":"end_test","name":"TestNodeScanCmd","result":"PASS","duration":350000000}
{"type":"end_test","name":"TestNodeScanCmd/\u003cprogname\u003e_-s_devstoreaccount1_-c_testnodescancmd_-t_tenant/0684984b-654d-4301-ad10-a508126e187d_nodescan_-m_0_-v_d7918c89c44bd508eb645fc4448abf89a8ebf63142b05801a65d590a05ad814b","result":"PASS","duration":50000000,"indent":1}
{"type":"status","result":"PASS"}
{"type":"coverage","coverage_percentage":18.4}
{"type":"summary","name":"github.com/datatrails/veracity","result":"ok","duration":2112000000,"coverage_percentage":18.4}