### PR TITLE
fix massif selection and peak stack init

### DIFF
--- a/eventsverify.go
+++ b/eventsverify.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/datatrails/go-datatrails-logverification/logverification"
+	"github.com/datatrails/go-datatrails-merklelog/massifs"
 	"github.com/datatrails/go-datatrails-merklelog/mmr"
 	"github.com/urfave/cli/v2"
 )
@@ -30,13 +31,12 @@ func proofPath(proof [][]byte) string {
 }
 
 func verifyEvent(event *logverification.VerifiableEvent, massifHeight uint8, massifReader MassifReader, forTenant string) ([][]byte, error) {
-
 	// Get the mmrIndex from the request and then compute the massif
 	// it implies based on the massifHeight command line option.
 	mmrIndex := event.MerkleLog.Commit.Index
 
 	tenantIdentity := forTenant
-	massifIndex := mmr.LeafIndex(mmrIndex+1) / mmr.HeightSize(uint64(massifHeight))
+	massifIndex := massifs.MassifIndexFromMMRIndex(massifHeight, mmrIndex)
 	if tenantIdentity == "" {
 		// The tenant identity on the event is the original tenant
 		// that created the event. For public assets and shared
@@ -73,7 +73,6 @@ func verifyEvent(event *logverification.VerifiableEvent, massifHeight uint8, mas
 	verified := mmr.VerifyInclusion(mmrSize, hasher, event.LeafHash, mmrIndex, proof, root)
 	if verified {
 		return proof, nil
-
 	}
 
 	return nil, fmt.Errorf("event not included")
@@ -147,6 +146,10 @@ Note: for publicly attested events, or shared protected events, you must use --t
 				log("verifying: %d %d %s %s", mmrIndex, leafIndex, event.MerkleLog.Commit.Idtimestamp, event.EventID)
 				proof, err := verifyEvent(&event, cmd.massifHeight, cmd.massifReader, tenantIdentity)
 				if err != nil {
+					if !errors.Is(err, ErrVerifyInclusionFailed) {
+						return err
+					}
+
 					countVerifyFailed += 1
 					log("XX|%d %d\n", mmrIndex, leafIndex)
 					continue

--- a/eventsverify.go
+++ b/eventsverify.go
@@ -146,10 +146,6 @@ Note: for publicly attested events, or shared protected events, you must use --t
 				log("verifying: %d %d %s %s", mmrIndex, leafIndex, event.MerkleLog.Commit.Idtimestamp, event.EventID)
 				proof, err := verifyEvent(&event, cmd.massifHeight, cmd.massifReader, tenantIdentity)
 				if err != nil {
-					if !errors.Is(err, ErrVerifyInclusionFailed) {
-						return err
-					}
-
 					countVerifyFailed += 1
 					log("XX|%d %d\n", mmrIndex, leafIndex)
 					continue

--- a/localmassifreader.go
+++ b/localmassifreader.go
@@ -251,6 +251,13 @@ func (mr *LocalMassifReader) readAndPrepareContext(mc *massifs.MassifContext, ma
 		return err
 	}
 
+	// Note: Where the regular massif reader has an option WithoutGetRootSupport, that is not useful
+	// for simply reading local massifs so we omit the conditional guard and always create the peak
+	// stack map.
+	if err = mc.CreatePeakStackMap(); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
1. Massif selection logic was incorrect, so updated this to use the function in the massifs package.
2. MassifReader has some conditional logic to create the peak stack map if !WithoutGetRootSupport. This was not included in LocalMassifReader - causing failures when loading the second massif.

---
### Testing Output
Local Massifs

```
cat ~/before-and-after.json | ./veracity --data-local test-logs --tenant=$PUBLIC_TENANT_ID --loglevel=INFO verify-included
verifying events dir: 
verifying for tenant: tenant/845c314b-a3ac-88b7-8580-fc70ddd87fc9

verifying: 16369 8191 01917f841268016600 publicassets/9fa27409-9eba-4e3e-a740-752eb187028b/events/03c130b2-04bc-49b5-9f1d-d3a6a8b8d28f
OK|16369 8191|[746273e9b8e246e582ea815000c123221019042ed662d63aab8e4c795f2506b0, 4a50d5398f8af9266ff5b2c93f7d8f7d86080b38915408d7eb741f6a93717dec, 6a91befb5d4462f67a5d98cae7720063c41fb457bdcfd39c27be22619e4ebb11, e3452982c5430fecb24f03c675083b7d633aee1e4431be6e5830a02f746d62e0, 1ce3487b3c7f35df8168816c63056430f5b6622d2ae7f068e1d7e16d0533c679, 4529321b71d993206b3ce0b978d9bbd626356855a48958f4bfeeff7a360906bf, 4478f2c9c2f7067e78e1f65565ef9ae8ed3550641a12af415051e35a66008396, 0a81c0115c440e7f10365a8e3399dc0121eb65968069470aa33c4c0747a1bf74, b86c16eb50117f8c391a2bc2fc6a60a1ec5595e0dc7f00719570639d2705bf3c, de417218189ae7fc255abf517dcea9df561d534a5f06f93d898c820addbb769a, 8d7138d3837d272b50be4c0dab5215cf128a1459206dc8650329302dc1deacde, 52a4e938792f863ed5bae3e8c08171423debe4a4935d7a4d96308ed5758699a4, 77fb62e40e549c81f09864fe465847178acf6e08479ef4e4545353bd6f3204f6]

verifying: 16383 8192 01917f841769016600 publicassets/9fa27409-9eba-4e3e-a740-752eb187028b/events/5372f715-289d-49ee-b533-ea3137106403
OK|16383 8192|[bedf8f6c18fda76789f367ebcaf5239918b1630152697d41f6bd12d0767a4017, d8c998743c84ddf811ec63567e1b3771bcb942364788fb4881ab663297495d6e, b3dcfea4b61363c6e20932c3c2b13176d25fa123196a0b6ae150ae78099c93de, 0f1afd6f6b1858cf4cdda1e1716c6a14bf21840574eeab11738aef7fc1acf322, 579abcda1be703f307651aaf6c3f36ad5f50f1c93832a9367b4c0d41026693ad, 4bb2a63aab5ca50f84d364f13f973ec1c88fca93c397d979943272a2628d725f, d55f5b48b3d13e509666d42cec2da2a4bc82ef7e6c798c48d3094fe789c736b6, 54faabb8959ccbb2bf1333f6495bb0392ef12c660784b7d8bc7f055fb95abd16, a4efd44c333e335e5cdf3ad76bd15438a526911cfc3bf4a7927323fd58bb5e5a, 5492ee832fc7401e21965c3560b70b361b0f74766643fe0690ee7ad6f0ca9ecf, 0fba02cc7e2fd4ecc6dbc8e80064b436d506c13b32b789c3f86b539d0a19d252, f3242f1f7c1ff0417fcdab267f5927af4806d86abb1551d231137407257a54a2]
```

Remote Massifs
```
cat ~/before-and-after.json |     ./veracity     --data-url=$DATATRAILS_URL/verifiabledata     --tenant=$PUBLIC_TENANT_ID     --loglevel=INFO     verify-included
verifying events dir: 
defaulting to the standard container merklelogs
verifying for tenant: tenant/845c314b-a3ac-88b7-8580-fc70ddd87fc9

verifying: 16369 8191 01917f841268016600 publicassets/9fa27409-9eba-4e3e-a740-752eb187028b/events/03c130b2-04bc-49b5-9f1d-d3a6a8b8d28f
OK|16369 8191|[746273e9b8e246e582ea815000c123221019042ed662d63aab8e4c795f2506b0, 4a50d5398f8af9266ff5b2c93f7d8f7d86080b38915408d7eb741f6a93717dec, 6a91befb5d4462f67a5d98cae7720063c41fb457bdcfd39c27be22619e4ebb11, e3452982c5430fecb24f03c675083b7d633aee1e4431be6e5830a02f746d62e0, 1ce3487b3c7f35df8168816c63056430f5b6622d2ae7f068e1d7e16d0533c679, 4529321b71d993206b3ce0b978d9bbd626356855a48958f4bfeeff7a360906bf, 4478f2c9c2f7067e78e1f65565ef9ae8ed3550641a12af415051e35a66008396, 0a81c0115c440e7f10365a8e3399dc0121eb65968069470aa33c4c0747a1bf74, b86c16eb50117f8c391a2bc2fc6a60a1ec5595e0dc7f00719570639d2705bf3c, de417218189ae7fc255abf517dcea9df561d534a5f06f93d898c820addbb769a, 8d7138d3837d272b50be4c0dab5215cf128a1459206dc8650329302dc1deacde, 52a4e938792f863ed5bae3e8c08171423debe4a4935d7a4d96308ed5758699a4, 77fb62e40e549c81f09864fe465847178acf6e08479ef4e4545353bd6f3204f6]

verifying: 16383 8192 01917f841769016600 publicassets/9fa27409-9eba-4e3e-a740-752eb187028b/events/5372f715-289d-49ee-b533-ea3137106403
OK|16383 8192|[bedf8f6c18fda76789f367ebcaf5239918b1630152697d41f6bd12d0767a4017, d8c998743c84ddf811ec63567e1b3771bcb942364788fb4881ab663297495d6e, b3dcfea4b61363c6e20932c3c2b13176d25fa123196a0b6ae150ae78099c93de, 0f1afd6f6b1858cf4cdda1e1716c6a14bf21840574eeab11738aef7fc1acf322, 579abcda1be703f307651aaf6c3f36ad5f50f1c93832a9367b4c0d41026693ad, 4bb2a63aab5ca50f84d364f13f973ec1c88fca93c397d979943272a2628d725f, d55f5b48b3d13e509666d42cec2da2a4bc82ef7e6c798c48d3094fe789c736b6, 54faabb8959ccbb2bf1333f6495bb0392ef12c660784b7d8bc7f055fb95abd16, a4efd44c333e335e5cdf3ad76bd15438a526911cfc3bf4a7927323fd58bb5e5a, 5492ee832fc7401e21965c3560b70b361b0f74766643fe0690ee7ad6f0ca9ecf, 0fba02cc7e2fd4ecc6dbc8e80064b436d506c13b32b789c3f86b539d0a19d252, f3242f1f7c1ff0417fcdab267f5927af4806d86abb1551d231137407257a54a2]
```

re AB#9827