### PR TITLE
fix: snags and bugs revealed by docs writing

### DIFF
--- a/app.go
+++ b/app.go
@@ -22,6 +22,7 @@ func NewApp(ikwid bool) *cli.App {
 			},
 			&cli.StringFlag{
 				Name: "tenant", Aliases: []string{"t"},
+				Usage: "tenant or list of tenants as a `,` separated list. commands which operate on a single tenant take the first tenant in the list",
 			},
 		},
 	}

--- a/cfgmassif.go
+++ b/cfgmassif.go
@@ -95,7 +95,7 @@ func cfgMassif(cmd *CmdCtx, cCtx *cli.Context) error {
 		return err
 	}
 
-	tenant := cCtx.String("tenant")
+	tenant := CtxGetOneTenantOption(cCtx)
 	if tenant == "" {
 		return fmt.Errorf("tenant must be provided for this command")
 	}

--- a/cfgrootreader.go
+++ b/cfgrootreader.go
@@ -17,8 +17,8 @@ func cfgRootReader(cmd *CmdCtx, cCtx *cli.Context) error {
 		return err
 	}
 
-	// TODO: We'll probably want to update this in future, in order to have a helpful default route.
-	reader, err := cfgReader(cmd, cCtx, false)
+	forceProdUrl := cCtx.String("data-local") == "" && cCtx.String("data-url") == ""
+	reader, err := cfgReader(cmd, cCtx, forceProdUrl)
 	if err != nil {
 		return err
 	}

--- a/cfgtenants.go
+++ b/cfgtenants.go
@@ -1,0 +1,39 @@
+package veracity
+
+import (
+	"fmt"
+	"strings"
+)
+
+// NormTenantIdentity ensures a string is prefixed with 'tenant/'
+// Note the expected input is a uuid string or a tenant/uuid string
+func NormTenantIdentity(tenant string) string {
+	if strings.HasPrefix(tenant, tenantPrefix) {
+		return tenant
+	}
+	return fmt.Sprintf("%s%s", tenantPrefix, tenant)
+}
+
+type cliContextString interface {
+	String(name string) string
+}
+
+func CtxGetTenantOptions(cCtx cliContextString) []string {
+	if cCtx.String("tenant") == "" {
+		return nil
+	}
+	values := strings.Split(cCtx.String("tenant"), ",")
+	var tenants []string
+	for _, v := range values {
+		tenants = append(tenants, NormTenantIdentity(v))
+	}
+	return tenants
+}
+
+func CtxGetOneTenantOption(cCtx cliContextString) string {
+	tenants := CtxGetTenantOptions(cCtx)
+	if tenants == nil {
+		return ""
+	}
+	return tenants[0]
+}

--- a/replicatelogs.go
+++ b/replicatelogs.go
@@ -100,9 +100,15 @@ changes are read from standard input.`,
 						errChan <- err
 						return
 					}
+					endMassif := uint32(change.Massif)
+					startMassif := uint32(0)
+					if cCtx.IsSet("ancestors") && uint32(cCtx.Int("ancestors")) < endMassif {
+						startMassif = endMassif - uint32(cCtx.Int("ancestors"))
+					}
+
 					err = replicator.ReplicateVerifiedUpdates(
 						context.Background(),
-						change.Tenant, uint32(change.Massif), uint32(cCtx.Uint("ancestors")),
+						change.Tenant, startMassif, endMassif,
 					)
 					if err != nil {
 						errChan <- err
@@ -244,7 +250,7 @@ func NewVerifiedReplica(
 // interesting.
 func (v *VerifiedReplica) ReplicateVerifiedUpdates(
 	ctx context.Context,
-	tenantIdentity string, headMassifIndex uint32, ancestorCount uint32) error {
+	tenantIdentity string, startMassif, endMassif uint32) error {
 
 	isNilOrNotFound := func(err error) bool {
 		if err == nil {
@@ -271,70 +277,67 @@ func (v *VerifiedReplica) ReplicateVerifiedUpdates(
 		return err
 	}
 
-	// Read the most recently verified state from the lastLocal store. The
-	// verification ensures the lastLocal replica has not been corrupted, but this
+	// Read the most recently verified state from the local store. The
+	// verification ensures the local replica has not been corrupted, but this
 	// check trusts the seal stored locally with the head massif
-	lastLocal, err := v.localReader.GetHeadVerifiedContext(ctx, tenantIdentity)
+	local, err := v.localReader.GetHeadVerifiedContext(ctx, tenantIdentity)
 	if !isNilOrNotFound(err) {
 		return err
 	}
 
-	var local *massifs.VerifiedContext
-
-	// We always verify up to the requested massif.
-	// ancestorCount is used to ensure there is a minimum number of verified massifs replicated locally.
-	// Our verification always reads the remote massifs starting from requested - ancestorCount.
+	// We always verify up to the requested massif, but we do not re-verify
+	// massifs we have already verified and replicated localy. If the last
+	// locally replicated masif is ahead of the endMassif we do nothing here.
+	//
+	// The --ancestors option is used to ensure there is a minimum number of
+	// verified massifs replicated locally, and influnces the startMassif to
+	// acheive this.
+	//
+	// The startMassif is the greater of the requested start and the massif
+	// index of the last locally verified massif.  Our verification always reads
+	// the remote massifs starting from the startMassif.
+	//
 	// In the loop below we ensure three key things:
 	// 1. If there is a local replica of the remote, we ensure the remote is
 	//   consistent with the replica.
 	// 2. If the remote starts a new massif, and we locally have its
-	//    predecessor, we ensure the remote is consistent with the local.
-	// 3. If there is no local replica, we create one from the remote.
+	//    predecessor, we ensure the remote is consistent with the local predecessor.
+	// 3. If there is no local replica, we create one by copying the the remote.
 	//
-	// In call cases we first verify the remote against the remote seal.  The
-	// --ancestors can be used to limit the number of predecesor massifs that
-	// are verified before the changed massifs. In the case, consistency with
-	// the local replica is only checked if the local replica is sufficiently up
-	// to date. If it is not, no attempt is made to "fill the gap".
+	// Note that we arrange things so that local is always the last avaible
+	// local massif, or nil.  When dealing with the remote corresponding to
+	// startMassif, the local is *either* the predecessor or is the incomplete
+	// local replica of the remote being considered. After the first remote is
+	// dealt with, local is always the predecessor.
 
-	i := headMassifIndex - ancestorCount
-	if ancestorCount == 0 {
-		// a full replica is requested
-		i = 0
-	}
-	if lastLocal != nil {
+	if local != nil {
 
-		// In the case where the requested head is 2 or more ahead of the local
-		// state we do not attempt to automaticaly back fill. This is so it is
-		// possible to ensure a bounded number of requests (and copies) in
-		// situations where verifiers have been off line for a long time.
-		//
-		// Explicit back filling is always possible by running with --ancestor=0
-		// or by running the command multiple times with increasing --massif
+		if startMassif < local.Start.MassifIndex {
+			return nil
+		}
 
-		// With that accounted for, we then want to avoid re-verifying the state
-		// we have already verified locally, hence the use of `max`.
-		// We make no attempt to deal with "sparse" collections of massifs, the
-		// most recent locally available is what we verify the remote against.
-
-		i = max(lastLocal.Start.MassifIndex, i)
-		if i > lastLocal.Start.MassifIndex+1 {
+		// Start from the next massif after the last verified massif and do not
+		// re-verify massifs we have already verified and replicated,
+		if startMassif > local.Start.MassifIndex+1 {
 			// if the start of the ancestors is more than one massif ahead of
 			// the local, then we start afresh.
-			lastLocal = nil
+			local = nil
+		} else {
+			// min is safe because we return above if startMassif is less than local.Start.MassifIndex
+			startMassif = min(local.Start.MassifIndex+1, startMassif)
 		}
 	}
 
-	for ; i <= headMassifIndex; i++ {
+	for i := startMassif; i <= endMassif; i++ {
 
-		// Read the remote massif, providing our locally trusted (and just
-		// re-verified) state as the trusted base This will cause the remote
-		// massif to be verified against the remote seal and the seal we have
-		// locally replicated. On the first iteration, lastLocal will be nil or
-		// it will corespond to the remote masssif i or i-1.
+		// On the first iteration local is *either* the predecessor to
+		// startMassif or it is the, as yet, incomplete local replica of it.
+		// After the first iteration, local is always the predecessor. (If the
+		// remote is still incomplte it means there is no subseqent massif to
+		// read)
 		remote, err := v.remoteReader.GetVerifiedContext(
 			ctx, tenantIdentity, uint64(i),
-			append(remoteOptionsFromLocal(lastLocal), massifs.WithCBORCodec(v.cborCodec))...)
+			append(remoteOptionsFromLocal(local), massifs.WithCBORCodec(v.cborCodec))...)
 		if err != nil {
 			// both the remote massif and it's seal must be present for the
 			// verification to succeed, so we don't filter using isBlobNotFound
@@ -342,20 +345,19 @@ func (v *VerifiedReplica) ReplicateVerifiedUpdates(
 			return err
 		}
 
-		// read the local massif, if it exists
+		// next round, use the just replicated remote as the trusted base for verification
+
+		// read the local massif, if it exists, reading at the end of the loop
 		local, err = v.localReader.GetVerifiedContext(ctx, tenantIdentity, uint64(i))
 		if !isNilOrNotFound(err) {
 			return err
 		}
 
 		// copy the remote locally, safely replacing the coresponding local if one exists
-		err = v.replicateVerifiedContext(ctx, local, remote)
+		err = v.replicateVerifiedContext(local, remote)
 		if err != nil {
 			return err
 		}
-
-		// next round, use the just replicated remote as the trusted base for verification
-		lastLocal = local
 	}
 
 	return nil
@@ -373,7 +375,6 @@ func (v *VerifiedReplica) ReplicateVerifiedUpdates(
 // This method has no side effects in the case where the remote and the local
 // are verified to be identical, the original local instance is retained.
 func (v *VerifiedReplica) replicateVerifiedContext(
-	ctx context.Context,
 	local *massifs.VerifiedContext, remote *massifs.VerifiedContext) error {
 
 	if local == nil {

--- a/replicatelogs.go
+++ b/replicatelogs.go
@@ -31,7 +31,7 @@ var (
 func NewReplicateLogsCmd() *cli.Command {
 	return &cli.Command{
 		Name:    "replicate-logs",
-		Aliases: []string{"consistent"},
+		Aliases: []string{"replicate"},
 		Usage:   `verifies the remote log and replicates it locally, ensuring the remote changes are consistent with the trusted local replica.`,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{Name: skipUncommittedFlagName, Value: false},

--- a/tests/env.go
+++ b/tests/env.go
@@ -42,6 +42,7 @@ type TestEnv struct {
 	MerklelogAccountName string
 	MerklelogURL         string
 	PublicTenantId       string
+	SynsationTenantId string
 	MerkelogURLPrefix    string
 	PublicKey            string
 
@@ -70,6 +71,7 @@ func NewTestEnv() (TestEnv, error) {
 		VerifiableDataURL:        verifiableDataURL,
 		AzuriteVerifiableDataURL: azuriteVerifiableDataUrl,
 		PublicTenantId:           publicTenantId,
+		SynsationTenantId: 	  "tenant/6a009b40-eb55-4159-81f0-69024f89f53c",
 		PublicKey:                os.Getenv(publicKeyPrefixEnvKey),
 		UnknownTenantId:          fmt.Sprintf("tenant/%s", uuid.New().String()),
 	}

--- a/tests/env.go
+++ b/tests/env.go
@@ -42,7 +42,7 @@ type TestEnv struct {
 	MerklelogAccountName string
 	MerklelogURL         string
 	PublicTenantId       string
-	SynsationTenantId string
+	SynsationTenantId    string
 	MerkelogURLPrefix    string
 	PublicKey            string
 
@@ -71,7 +71,7 @@ func NewTestEnv() (TestEnv, error) {
 		VerifiableDataURL:        verifiableDataURL,
 		AzuriteVerifiableDataURL: azuriteVerifiableDataUrl,
 		PublicTenantId:           publicTenantId,
-		SynsationTenantId: 	  "tenant/6a009b40-eb55-4159-81f0-69024f89f53c",
+		SynsationTenantId:        "tenant/6a009b40-eb55-4159-81f0-69024f89f53c",
 		PublicKey:                os.Getenv(publicKeyPrefixEnvKey),
 		UnknownTenantId:          fmt.Sprintf("tenant/%s", uuid.New().String()),
 	}

--- a/tests/replicatelogs/replicatelogs_prod_test.go
+++ b/tests/replicatelogs/replicatelogs_prod_test.go
@@ -1,3 +1,5 @@
+//go:build integration && azurite
+
 package verifyconsistency
 
 import (

--- a/tests/watch/suite_test.go
+++ b/tests/watch/suite_test.go
@@ -1,4 +1,6 @@
-package verifyevents
+//go:build integration
+
+package watch
 
 import (
 	"testing"

--- a/tests/watch/watch_test.go
+++ b/tests/watch/watch_test.go
@@ -1,4 +1,4 @@
-//go:build integration && prodpublic
+//go:build integration
 
 package watch
 
@@ -6,39 +6,48 @@ import (
 	"github.com/datatrails/veracity"
 )
 
-// Test that the watch command returns no error or that the error is "no changes"
 func (s *WatchCmdSuite) TestNoErrorOrNoChanges() {
 
-	// NOTE: These will fail in the CI until the prod APIM principal gets the new custom role
-	assert := s.Assert()
-	app := veracity.NewApp(true)
-	veracity.AddCommands(app, true)
+	app := veracity.NewApp(false)
+	veracity.AddCommands(app, false)
 
 	err := app.Run([]string{
 		"veracity",
 		"--data-url", s.Env.VerifiableDataURL,
 		"watch",
+		"--horizon", "100000h", // 11 years, so we are sure we look back far enough to find an event
 	})
-
-	if err != nil {
-		assert.EqualErrorf(err, veracity.ErrNoChanges.Error(), "the only acceptable error is 'no changes'")
-	}
+	s.NoError(err)
 }
 
 // Test that when filtering results by an unknown tenant id, the result is no changes
 // The watch command does not check wether the tenants to "filter" for actually have logs
 func (s *WatchCmdSuite) TestNoChangesForFictitiousTenant() {
 	assert := s.Assert()
-	app := veracity.NewApp(true)
-	veracity.AddCommands(app, true)
+	app := veracity.NewApp(false)
+	veracity.AddCommands(app, false)
+	err := app.Run([]string{
+		"veracity",
+		"--data-url", s.Env.VerifiableDataURL,
+		"--tenant", s.Env.UnknownTenantId,
+		"watch",
+	})
+	assert.Equal(err, veracity.ErrNoChanges)
+}
+
+// Test that the watch command returns no error or that the error is "no changes"
+func (s *WatchCmdSuite) TestReplicateFirstPublicMassif() {
 
 	// NOTE: These will fail in the CI until the prod APIM principal gets the new custom role
+	app := veracity.NewApp(false)
+	veracity.AddCommands(app, false)
 
 	err := app.Run([]string{
 		"veracity",
 		"--data-url", s.Env.VerifiableDataURL,
+		"--tenant", s.Env.SynsationTenantId,
 		"watch",
-		"--tenant", s.Env.UknownTenantId,
+		"--horizon", "100000h", // 11 years, so we are sure we look back far enough to find an event
 	})
-	assert.Equal(err, veracity.ErrNoChanges)
+	s.NoError(err)
 }

--- a/watch.go
+++ b/watch.go
@@ -29,8 +29,6 @@ const (
 	// maxPollCount is the maximum number of times to poll for *some* activity.
 	// Polling always terminates as soon as the first activity is detected.
 	maxPollCount = 15
-
-	watchModeTenants = "tenants"
 )
 
 var (
@@ -41,7 +39,6 @@ type WatchConfig struct {
 	watcher.WatchConfig
 	WatchTenants map[string]bool
 	WatchCount   int
-	Mode         string
 	ReaderURL    string
 }
 
@@ -78,16 +75,14 @@ func NewLogWatcherCmd() *cli.Command {
 				Layout: time.RFC3339,
 			},
 			&cli.StringFlag{
-				Name:  "mode",
-				Usage: "Any of [summary, tenants], defaults to summary",
-				Value: "summary",
-			},
-			&cli.StringFlag{
 				Name: "idsince", Aliases: []string{"s"},
 				Usage: "Start time as an idtimestamp. Start time defaults to now. All results are >= this hex string. If provided, it is used exactly as is. Takes precedence over since",
 			},
 			&cli.DurationFlag{
-				Name: "horizon", Aliases: []string{"z"}, Value: time.Duration(0), Usage: "Infer since as now - horizon, aka 1h to onl see things in the last hour. If watching (count=0), since is re-calculated every interval",
+				Name:    "horizon",
+				Aliases: []string{"z"},
+				Value:   time.Duration(time.Hour * 24),
+				Usage:   "Infer since as now - horizon, aka 1h to onl see things in the last hour. If watching (count=0), since is re-calculated every interval",
 			},
 			&cli.DurationFlag{
 				Name: "interval", Aliases: []string{"d"},
@@ -98,10 +93,6 @@ func NewLogWatcherCmd() *cli.Command {
 				Name: "count", Usage: fmt.Sprintf(
 					"Number of intervals to poll. Polling is terminated once the first activity is seen or after %d attempts regardless", maxPollCount),
 				Value: 1,
-			},
-			&cli.StringFlag{
-				Name: "tenant", Aliases: []string{"t"},
-				Usage: "tenant to filter for, can be `,` separated list. by default all tenants are watched",
 			},
 		},
 		Action: func(cCtx *cli.Context) error {
@@ -154,20 +145,17 @@ func NewWatchConfig(cCtx cliContext, cmd *CmdCtx) (WatchConfig, error) {
 
 	cfg.WatchCount = min(max(1, cCtx.Int("count")), maxPollCount)
 
-	cfg.Mode = cCtx.String("mode")
-
 	cfg.ReaderURL = cmd.readerURL
 
-	if cCtx.String("tenant") != "" {
-		tenants := strings.Split(cCtx.String("tenant"), ",")
-		if len(tenants) > 0 {
-			cfg.WatchTenants = make(map[string]bool)
-			for _, t := range tenants {
-				cfg.WatchTenants[strings.TrimPrefix(t, tenantPrefix)] = true
-			}
-		}
+	tenants := CtxGetTenantOptions(cCtx)
+	if len(tenants) == 0 {
+		return cfg, nil
 	}
 
+	cfg.WatchTenants = make(map[string]bool)
+	for _, t := range tenants {
+		cfg.WatchTenants[strings.TrimPrefix(t, tenantPrefix)] = true
+	}
 	return cfg, nil
 }
 
@@ -177,6 +165,13 @@ type Watcher struct {
 	reader   azblob.Reader
 	reporter watchReporter
 	collator watcher.LogTailCollator
+}
+
+func normalizeTenantIdentity(tenant string) string {
+	if strings.HasPrefix(tenant, tenantPrefix) {
+		return tenant
+	}
+	return fmt.Sprintf("%s%s", tenantPrefix, tenant)
 }
 
 // WatchForChanges watches for tenant log chances according to the provided config
@@ -204,56 +199,53 @@ func WatchForChanges(
 			return err
 		}
 
-		switch w.cfg.Mode {
-		default:
-		case watchModeTenants:
-			var activity []TenantActivity
-			for _, tenant := range w.collator.SortedMassifTenants() {
-				if w.cfg.WatchTenants != nil && !w.cfg.WatchTenants[tenant] {
-					continue
-				}
-				lt := w.collator.Massifs[tenant]
-				sealLastID := lastSealID(w.collator, tenant)
-				// This is console mode output
-
-				a := TenantActivity{
-					Tenant:      tenant,
-					Massif:      int(lt.Number),
-					IDCommitted: lt.LastID, IDConfirmed: sealLastID,
-					LastModified: lastActivityRFC3339(lt.LastID, sealLastID),
-					MassifURL:    fmt.Sprintf("%s%s", w.cfg.ReaderURL, lt.Path),
-				}
-
-				if sealLastID != sealIDNotFound {
-					a.SealURL = fmt.Sprintf("%s%s", w.cfg.ReaderURL, w.collator.Seals[tenant].Path)
-				}
-
-				activity = append(activity, a)
+		var activity []TenantActivity
+		for _, tenant := range w.collator.SortedMassifTenants() {
+			if w.cfg.WatchTenants != nil && !w.cfg.WatchTenants[tenant] {
+				continue
 			}
 
-			if activity != nil {
-				reporter.Logf(
-					"%d active logs since %v (%s).",
-					len(w.collator.Massifs),
-					w.LastSince.Format(time.RFC3339),
-					w.LastIDSince,
-				)
-				reporter.Logf(
-					"%d tenants sealed since %v (%s).",
-					len(w.collator.Seals),
-					w.LastSince.Format(time.RFC3339),
-					w.LastIDSince,
-				)
+			lt := w.collator.Massifs[tenant]
+			sealLastID := lastSealID(w.collator, tenant)
+			// This is console mode output
 
-				marshaledJson, err := json.MarshalIndent(activity, "", "  ")
-				if err != nil {
-					return err
-				}
-				reporter.Outf(string(marshaledJson))
-
-				// Terminate immediately once we have results
-				return nil
+			a := TenantActivity{
+				Tenant:      normalizeTenantIdentity(tenant),
+				Massif:      int(lt.Number),
+				IDCommitted: lt.LastID, IDConfirmed: sealLastID,
+				LastModified: lastActivityRFC3339(lt.LastID, sealLastID),
+				MassifURL:    fmt.Sprintf("%s%s", w.cfg.ReaderURL, lt.Path),
 			}
+
+			if sealLastID != sealIDNotFound {
+				a.SealURL = fmt.Sprintf("%s%s", w.cfg.ReaderURL, w.collator.Seals[tenant].Path)
+			}
+
+			activity = append(activity, a)
+		}
+
+		if activity != nil {
+			reporter.Logf(
+				"%d active logs since %v (%s).",
+				len(w.collator.Massifs),
+				w.LastSince.Format(time.RFC3339),
+				w.LastIDSince,
+			)
+			reporter.Logf(
+				"%d tenants sealed since %v (%s).",
+				len(w.collator.Seals),
+				w.LastSince.Format(time.RFC3339),
+				w.LastIDSince,
+			)
+
+			marshaledJson, err := json.MarshalIndent(activity, "", "  ")
+			if err != nil {
+				return err
+			}
+			reporter.Outf(string(marshaledJson))
+
+			// Terminate immediately once we have results
+			return nil
 		}
 
 		// Note we don't allow a zero interval

--- a/watch.go
+++ b/watch.go
@@ -81,7 +81,7 @@ func NewLogWatcherCmd() *cli.Command {
 			&cli.DurationFlag{
 				Name:    "horizon",
 				Aliases: []string{"z"},
-				Value:   time.Duration(time.Hour * 24),
+				Value:   time.Hour * 24,
 				Usage:   "Infer since as now - horizon, aka 1h to onl see things in the last hour. If watching (count=0), since is re-calculated every interval",
 			},
 			&cli.DurationFlag{

--- a/watch_test.go
+++ b/watch_test.go
@@ -206,9 +206,7 @@ func TestWatchForChanges(t *testing.T) {
 		{
 			name: "three results, two pages",
 			args: args{
-				cfg: WatchConfig{
-					Mode: "tenants",
-				},
+				cfg: WatchConfig{},
 				reader: &mockReader{
 					results: []*azblob.FilterResponse{
 						{
@@ -234,7 +232,7 @@ func TestWatchForChanges(t *testing.T) {
 			wantOutputs: []string{string(marshalActivity(t,
 				TenantActivity{
 					Massif:       1,
-					Tenant:       "{tenant-1}",
+					Tenant:       "tenant/{tenant-1}",
 					MassifURL:    "v1/mmrs/tenant/{tenant-1}/massifs/0/0000000000000001.log",
 					SealURL:      "v1/mmrs/tenant/{tenant-1}/massifseals/0/0000000000000001.sth",
 					IDCommitted:  watchMakeId(Unix20231215T1344120000 + 1),
@@ -243,7 +241,7 @@ func TestWatchForChanges(t *testing.T) {
 				},
 				TenantActivity{
 					Massif:       1,
-					Tenant:       "{tenant-2}",
+					Tenant:       "tenant/{tenant-2}",
 					MassifURL:    "v1/mmrs/tenant/{tenant-2}/massifs/0/0000000000000001.log",
 					SealURL:      "v1/mmrs/tenant/{tenant-2}/massifseals/0/0000000000000001.sth",
 					IDCommitted:  watchMakeId(Unix20231215T1344120000 + 1),
@@ -252,7 +250,7 @@ func TestWatchForChanges(t *testing.T) {
 				},
 				TenantActivity{
 					Massif:       2,
-					Tenant:       "{tenant-3}",
+					Tenant:       "tenant/{tenant-3}",
 					MassifURL:    "v1/mmrs/tenant/{tenant-3}/massifs/0/0000000000000002.log",
 					SealURL:      "v1/mmrs/tenant/{tenant-3}/massifseals/0/0000000000000002.sth",
 					IDCommitted:  watchMakeId(Unix20231215T1344120000 + 1),
@@ -265,7 +263,6 @@ func TestWatchForChanges(t *testing.T) {
 			name: "three results, two tenants explicitly selected",
 			args: args{
 				cfg: WatchConfig{
-					Mode: "tenants",
 					WatchTenants: map[string]bool{
 						"{tenant-1}": true,
 						"{tenant-3}": true,
@@ -288,7 +285,7 @@ func TestWatchForChanges(t *testing.T) {
 			wantOutputs: []string{string(marshalActivity(t,
 				TenantActivity{
 					Massif:       1,
-					Tenant:       "{tenant-1}",
+					Tenant:       "tenant/{tenant-1}",
 					MassifURL:    "v1/mmrs/tenant/{tenant-1}/massifs/0/0000000000000001.log",
 					SealURL:      "v1/mmrs/tenant/{tenant-1}/massifseals/0/0000000000000001.sth",
 					IDCommitted:  watchMakeId(Unix20231215T1344120000 + 1),
@@ -297,7 +294,7 @@ func TestWatchForChanges(t *testing.T) {
 				},
 				TenantActivity{
 					Massif:       2,
-					Tenant:       "{tenant-3}",
+					Tenant:       "tenant/{tenant-3}",
 					MassifURL:    "v1/mmrs/tenant/{tenant-3}/massifs/0/0000000000000002.log",
 					SealURL:      "v1/mmrs/tenant/{tenant-3}/massifseals/0/0000000000000002.sth",
 					IDCommitted:  watchMakeId(Unix20231215T1344120000 + 1),
@@ -314,9 +311,7 @@ func TestWatchForChanges(t *testing.T) {
 			// "activity", and fetching the respective blobs is still the right
 			// course of action so veracity allows for it
 			args: args{
-				cfg: WatchConfig{
-					Mode: "tenants",
-				},
+				cfg: WatchConfig{},
 				reader: &mockReader{
 					results: []*azblob.FilterResponse{{
 						Items: newFilterBlobItems(
@@ -329,7 +324,7 @@ func TestWatchForChanges(t *testing.T) {
 			},
 			wantOutputs: []string{string(marshalActivity(t, TenantActivity{
 				Massif:       1,
-				Tenant:       "{UUID}",
+				Tenant:       "tenant/{UUID}",
 				MassifURL:    "v1/mmrs/tenant/{UUID}/massifs/0/0000000000000001.log",
 				SealURL:      "v1/mmrs/tenant/{UUID}/massifseals/0/0000000000000001.sth",
 				IDCommitted:  watchMakeId(Unix20231215T1344120000),
@@ -340,9 +335,7 @@ func TestWatchForChanges(t *testing.T) {
 		{
 			name: "one result, seal stale, last modified from log",
 			args: args{
-				cfg: WatchConfig{
-					Mode: "tenants",
-				},
+				cfg: WatchConfig{},
 				reader: &mockReader{
 					results: []*azblob.FilterResponse{{
 						Items: newFilterBlobItems(
@@ -355,7 +348,7 @@ func TestWatchForChanges(t *testing.T) {
 			},
 			wantOutputs: []string{string(marshalActivity(t, TenantActivity{
 				Massif:       1,
-				Tenant:       "{UUID}",
+				Tenant:       "tenant/{UUID}",
 				MassifURL:    "v1/mmrs/tenant/{UUID}/massifs/0/0000000000000001.log",
 				SealURL:      "v1/mmrs/tenant/{UUID}/massifseals/0/0000000000000001.sth",
 				IDCommitted:  watchMakeId(Unix20231215T1344120000 + 1),
@@ -366,9 +359,7 @@ func TestWatchForChanges(t *testing.T) {
 		{
 			name: "one result, seal not found",
 			args: args{
-				cfg: WatchConfig{
-					Mode: "tenants",
-				},
+				cfg: WatchConfig{},
 				reader: &mockReader{
 					results: []*azblob.FilterResponse{{
 						Items: newFilterBlobItems(
@@ -380,7 +371,7 @@ func TestWatchForChanges(t *testing.T) {
 			},
 			wantOutputs: []string{string(marshalActivity(t, TenantActivity{
 				Massif:       1,
-				Tenant:       "{UUID}",
+				Tenant:       "tenant/{UUID}",
 				MassifURL:    "v1/mmrs/tenant/{UUID}/massifs/0/0000000000000001.log",
 				SealURL:      "",
 				IDCommitted:  watchMakeId(Unix20231215T1344120000 + 1),
@@ -392,9 +383,7 @@ func TestWatchForChanges(t *testing.T) {
 		{
 			name: "no results",
 			args: args{
-				cfg: WatchConfig{
-					Mode: "tenants",
-				},
+				cfg:    WatchConfig{},
 				reader: &mockReader{},
 				reporter: &defaultReporter{
 					log: logger.Sugar,


### PR DESCRIPTION
* There was a corner case in replicate-logs where --ancestors was equal or lestthe number of massifs. this is now fixed and has tests. Bug #9856
* The watch command had a superflous mode option. this has been removed. #9854
* The watch command output was reporting tenant uuids rather than identities, it now reports identities. Bug #9855
* The --tenant option was used inconistently by some sub commands, this is now always a global option. Individual commands are free to support a list of comma seperated tenants. If a list is provided to a command that only deals with one, the command will take the first. #9857
* All commands which read seals failed to use the production url by default. #9858