### PR TITLE
Dev/robin/9894 show progress indication

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          # make tags available for the build
+          fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
           go-version: '1.22'

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -57,6 +57,9 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v3
+        with:
+          # make tags available for the build
+          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,6 +24,8 @@ builds:
       # testing it.
       - linux
       - darwin
+  - ldflags:
+      - "-X veracity.version={{.Version}} -X veracity.commit={{.Commit}} -X veracity.buildDate={{.Date}}"
 
 archives:
   - format: tar.gz

--- a/app.go
+++ b/app.go
@@ -6,9 +6,15 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func NewApp(ikwid bool) *cli.App {
+func NewApp(version string, ikwid bool) *cli.App {
+
+	cli.VersionPrinter = func(cCtx *cli.Context) {
+		fmt.Println(cCtx.App.Version)
+	}
 	app := &cli.App{
-		Usage: "common read only operations on datatrails merklelog verifiable data",
+		Name:    "veracity",
+		Version: version,
+		Usage:   "common read only operations on datatrails merklelog verifiable data",
 		Flags: []cli.Flag{
 			&cli.StringFlag{Name: "loglevel", Value: "NOOP"},
 			&cli.Int64Flag{Name: "height", Value: 14, Usage: "override the massif height"},

--- a/cmd/veracity/main.go
+++ b/cmd/veracity/main.go
@@ -9,14 +9,30 @@ import (
 	"github.com/datatrails/veracity"
 )
 
+// Note: the ci does the right thing with go-releaser automatically, as
+// configured in the repo's .goreleaser.yml file.
+// Also, task build:fast sets the ldflags correctly for the version, commit, and
+// build date so it is clear if a developer build is used.
+var (
+	version   string
+	commit    string
+	buildDate string
+)
+
 func main() {
+
+	versionString := "unknown"
+	if version != "" {
+		// versionString = fmt.Sprintf("%s %s %s", version, commit, buildDate)
+		versionString = fmt.Sprintf("%s %s", version, commit)
+	}
 
 	ikwid := false
 	envikwid := os.Getenv("VERACITY_IKWID")
 	if envikwid == "1" || strings.ToLower(envikwid) == "true" {
 		ikwid = true
 	}
-	app := veracity.NewApp(ikwid)
+	app := veracity.NewApp(versionString, ikwid)
 	veracity.AddCommands(app, ikwid)
 	if err := app.Run(os.Args); err != nil {
 		fmt.Printf("error: %v\n", err)

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/datatrails/go-datatrails-merklelog/mmr v0.0.2
 	github.com/datatrails/go-datatrails-merklelog/mmrtesting v0.1.0
 	github.com/datatrails/go-datatrails-simplehash v0.0.5
+	github.com/gosuri/uiprogress v0.0.1
 	github.com/urfave/cli/v2 v2.27.1
 	github.com/zeebo/bencode v1.0.0
 )
@@ -20,6 +21,8 @@ require (
 
 require (
 	github.com/envoyproxy/protoc-gen-validate v1.0.4 // indirect
+	github.com/gosuri/uilive v0.0.4 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,10 @@ github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gosuri/uilive v0.0.4 h1:hUEBpQDj8D8jXgtCdBu7sWsy5sbW/5GhuO8KBwJ2jyY=
+github.com/gosuri/uilive v0.0.4/go.mod h1:V/epo5LjjlDE5RJUcqx8dbw+zc93y5Ya3yg8tfZ74VI=
+github.com/gosuri/uiprogress v0.0.1 h1:0kpv/XY/qTmFWl/SkaJykZXrBBzwwadmW8fRb7RJSxw=
+github.com/gosuri/uiprogress v0.0.1/go.mod h1:C1RTYn4Sc7iEyf6j8ft5dyoZ4212h8G1ol9QQluh5+0=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1 h1:/c3QmbOGMGTOumP2iT/rCwB7b0QDGLKzqOmktBjT+Is=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1/go.mod h1:5SN9VR2LTsRFsrEC6FHgRbTWrTHu6tqPeKxEQv15giM=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
@@ -97,6 +101,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/ldclabs/cose/go v0.0.0-20221214142927-d22c1cfc2154 h1:+ANMOp3EbA4WEKS/jZi3jlyoNMFMDeq0+dXFxMdOwBc=
 github.com/ldclabs/cose/go v0.0.0-20221214142927-d22c1cfc2154/go.mod h1:ItUTr90SrkBAvLf5UsxqN+lMfF1rw21mEcFa28XqOzQ=
+github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
+github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492 h1:lM6RxxfUMrYL/f8bWEUqdXrANWtrL7Nndbm9iFN0DlU=
@@ -170,6 +176,7 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
 golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/node_test.go
+++ b/node_test.go
@@ -43,7 +43,7 @@ func TestNodeCmd(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(strings.Join(tc.testArgs, " "), func(t *testing.T) {
-			app := AddCommands(NewApp(true), true)
+			app := AddCommands(NewApp("version", true), true)
 			ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
 			err := app.RunContext(ctx, tc.testArgs)
 			cancel()

--- a/nodescan_test.go
+++ b/nodescan_test.go
@@ -76,7 +76,7 @@ func TestNodeScanCmd(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(strings.Join(tc.testArgs, " "), func(t *testing.T) {
-			app := AddCommands(NewApp(true), true)
+			app := AddCommands(NewApp("version", true), true)
 			ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
 			err := app.RunContext(ctx, tc.testArgs)
 			cancel()

--- a/progress.go
+++ b/progress.go
@@ -23,10 +23,12 @@ type progress struct {
 	bar *uiprogress.Bar
 }
 
-func NewStagedProgress(prefix string, count int) *progress {
-	increments := count
+func NewStagedProgress(prefix string, count int) Progresser {
+	if count == 0 {
+		return NewNoopProgress()
+	}
 	return &progress{
-		bar: uiprogress.AddBar(increments).PrependElapsed().PrependFunc(func(b *uiprogress.Bar) string {
+		bar: uiprogress.AddBar(count).PrependElapsed().PrependFunc(func(b *uiprogress.Bar) string {
 			return prefix + ":"
 		}),
 	}

--- a/progress.go
+++ b/progress.go
@@ -1,33 +1,17 @@
 package veracity
 
 import (
-	"errors"
-
 	"github.com/gosuri/uiprogress"
-)
-
-var (
-	ErrProgressStepInvalid = errors.New("the reported progress step is invalid")
 )
 
 type noopStagedProgressor struct{}
 
-func (p *noopStagedProgressor) Completed(string, bool) error {
-	return nil
-}
+func (p *noopStagedProgressor) Completed() {}
 
-func (p *noopStagedProgressor) Current() string { return "" }
-func (p *noopStagedProgressor) ICurrent() int   { return 0 }
-func (p *noopStagedProgressor) Steps() []string { return nil }
+func (p *noopStagedProgressor) Current() int { return 0 }
 
 type Progresser interface {
-	// Completed advances the progress bar up to the next named step.
-	// If forceNext is true, all remaining steps are completed regardless of the step name
-	// If step is *before* the current or is not found, an  error is returned.
-	Completed(string, bool) error
-	Current() string
-	ICurrent() int
-	Steps() []string
+	Completed()
 }
 
 func NewNoopProgress() Progresser {
@@ -35,66 +19,23 @@ func NewNoopProgress() Progresser {
 }
 
 type progress struct {
-	stages []string
 	// bar represents progress towards completion of massifs for a single tenant
 	bar *uiprogress.Bar
 }
 
-func NewStagedProgress(prefix string, count int, steps []string) *progress {
+func NewStagedProgress(prefix string, count int) *progress {
 	increments := count
-	if len(steps) > 0 {
-		increments = count * len(steps)
-	}
 	return &progress{
-		stages: steps,
 		bar: uiprogress.AddBar(increments).PrependElapsed().PrependFunc(func(b *uiprogress.Bar) string {
-			if len(steps) > 0 {
-				// return tenant + ": " + steps[(b.Current()%count)-1]
-				cur := b.Current()
-				i := ((cur + 1) % increments) - 1
-				return prefix + ": " + steps[i]
-			}
-			return prefix
+			return prefix + ":"
 		}),
 	}
 }
 
-// Current returns the name of the current step.
-func (p *progress) Current() string { return p.stages[p.ICurrent()] }
+// Current returns the index of the current step.
+func (p *progress) Current() int { return p.bar.Current() }
 
-// ICurrent returns the index of the current step.
-func (p *progress) ICurrent() int { return (p.bar.Current() % (p.bar.Total / len(p.stages))) - 1 }
-
-// Steps returns the names of the steps.
-func (p *progress) Steps() []string { return p.stages[:] }
-
-// Completed advances the progress bar up to the next named step.
-// If forceNext is true, all remaining steps are completed regardless of the step name
-// If step is *before* the current or is not found, an  error is returned.
-func (p *progress) Completed(step string, forceNext bool) error {
-	if len(p.stages) == 0 {
-		p.bar.Incr()
-		return nil
-	}
-	cur := ((p.bar.Current()+1) % (p.bar.Total / len(p.stages)))
-
-	var next int
-	for next = 0; next < len(p.stages); next++ {
-		if step == p.stages[next] {
-			break
-		}
-	}
-	if forceNext {
-		next = len(p.stages) - 1
-	}
-	if next < cur || next == len(p.stages) {
-		return ErrProgressStepInvalid
-	}
-	if next == cur {
-		return nil
-	}
-	for ; cur <= next; cur++ {
-		p.bar.Incr()
-	}
-	return nil
+// Completed advances the progress bar one increment
+func (p *progress) Completed() {
+	p.bar.Incr()
 }

--- a/progress.go
+++ b/progress.go
@@ -1,0 +1,100 @@
+package veracity
+
+import (
+	"errors"
+
+	"github.com/gosuri/uiprogress"
+)
+
+var (
+	ErrProgressStepInvalid = errors.New("the reported progress step is invalid")
+)
+
+type noopStagedProgressor struct{}
+
+func (p *noopStagedProgressor) Completed(string, bool) error {
+	return nil
+}
+
+func (p *noopStagedProgressor) Current() string { return "" }
+func (p *noopStagedProgressor) ICurrent() int   { return 0 }
+func (p *noopStagedProgressor) Steps() []string { return nil }
+
+type Progresser interface {
+	// Completed advances the progress bar up to the next named step.
+	// If forceNext is true, all remaining steps are completed regardless of the step name
+	// If step is *before* the current or is not found, an  error is returned.
+	Completed(string, bool) error
+	Current() string
+	ICurrent() int
+	Steps() []string
+}
+
+func NewNoopProgress() Progresser {
+	return &noopStagedProgressor{}
+}
+
+type progress struct {
+	stages []string
+	// bar represents progress towards completion of massifs for a single tenant
+	bar *uiprogress.Bar
+}
+
+func NewStagedProgress(prefix string, count int, steps []string) *progress {
+	increments := count
+	if len(steps) > 0 {
+		increments = count * len(steps)
+	}
+	return &progress{
+		stages: steps,
+		bar: uiprogress.AddBar(increments).PrependElapsed().PrependFunc(func(b *uiprogress.Bar) string {
+			if len(steps) > 0 {
+				// return tenant + ": " + steps[(b.Current()%count)-1]
+				cur := b.Current()
+				i := ((cur + 1) % increments) - 1
+				return prefix + ": " + steps[i]
+			}
+			return prefix
+		}),
+	}
+}
+
+// Current returns the name of the current step.
+func (p *progress) Current() string { return p.stages[p.ICurrent()] }
+
+// ICurrent returns the index of the current step.
+func (p *progress) ICurrent() int { return (p.bar.Current() % (p.bar.Total / len(p.stages))) - 1 }
+
+// Steps returns the names of the steps.
+func (p *progress) Steps() []string { return p.stages[:] }
+
+// Completed advances the progress bar up to the next named step.
+// If forceNext is true, all remaining steps are completed regardless of the step name
+// If step is *before* the current or is not found, an  error is returned.
+func (p *progress) Completed(step string, forceNext bool) error {
+	if len(p.stages) == 0 {
+		p.bar.Incr()
+		return nil
+	}
+	cur := ((p.bar.Current()+1) % (p.bar.Total / len(p.stages)))
+
+	var next int
+	for next = 0; next < len(p.stages); next++ {
+		if step == p.stages[next] {
+			break
+		}
+	}
+	if forceNext {
+		next = len(p.stages) - 1
+	}
+	if next < cur || next == len(p.stages) {
+		return ErrProgressStepInvalid
+	}
+	if next == cur {
+		return nil
+	}
+	for ; cur <= next; cur++ {
+		p.bar.Incr()
+	}
+	return nil
+}

--- a/replicatelogs.go
+++ b/replicatelogs.go
@@ -10,6 +10,7 @@ import (
 	"github.com/datatrails/go-datatrails-common/cbor"
 	"github.com/datatrails/go-datatrails-common/logger"
 	"github.com/datatrails/go-datatrails-merklelog/massifs"
+	"github.com/gosuri/uiprogress"
 	"github.com/urfave/cli/v2"
 )
 
@@ -68,6 +69,12 @@ to verify and replicate.  This is mutually exclusive with the --massif and
 --tenant flags. If none of --massif, --tenant or --changes are provided, the
 changes are read from standard input.`,
 			},
+			&cli.BoolFlag{
+				Name:    "progress",
+				Usage:   `show progress of the replication process`,
+				Value:   false,
+				Aliases: []string{"p"},
+			},
 		},
 		Action: func(cCtx *cli.Context) error {
 			cmd := &CmdCtx{}
@@ -87,6 +94,11 @@ changes are read from standard input.`,
 				return err
 			}
 
+			if cCtx.Bool("progress") {
+				uiprogress.Start()
+			}
+			progress := newProgressor(cCtx, "tenants", len(changes)-1)
+
 			var wg sync.WaitGroup
 			errChan := make(chan error, len(changes)) // buffered so it doesn't block
 
@@ -94,8 +106,9 @@ changes are read from standard input.`,
 				wg.Add(1)
 				go func(change TenantMassif, errChan chan<- error) {
 					defer wg.Done()
-					replicator, err := NewVerifiedReplica(
-						cCtx, cmd.Clone())
+					defer progress.Completed()
+
+					replicator, err := NewVerifiedReplica(cCtx, cmd.Clone())
 					if err != nil {
 						errChan <- err
 						return
@@ -128,9 +141,22 @@ changes are read from standard input.`,
 			if len(errs) > 0 {
 				return errs[0]
 			}
+			if len(changes) == 1 {
+				cmd.log.Infof("replication complete for tenant %s", changes[0].Tenant)
+			} else {
+				cmd.log.Infof("replication complete for %d tenants", len(changes))
+			}
 			return nil
 		},
 	}
+}
+
+func newProgressor(cCtx *cli.Context, barName string, increments int) Progresser {
+
+	if !cCtx.Bool("progress") {
+		return NewNoopProgress()
+	}
+	return NewStagedProgress(barName, increments)
 }
 
 func readTenantMassifChanges(cCtx *cli.Context) ([]TenantMassif, error) {
@@ -169,6 +195,7 @@ type VerifiedContextReader interface {
 }
 
 type VerifiedReplica struct {
+	cCtx         *cli.Context
 	log          logger.Logger
 	writeOpener  massifs.WriteAppendOpener
 	localReader  massifs.ReplicaReader
@@ -235,6 +262,7 @@ func NewVerifiedReplica(
 	)
 
 	return &VerifiedReplica{
+		cCtx:         cCtx,
 		log:          logger.Sugar,
 		writeOpener:  NewFileWriteOpener(),
 		localReader:  &localReader,

--- a/replicatelogs.go
+++ b/replicatelogs.go
@@ -97,7 +97,7 @@ changes are read from standard input.`,
 			if cCtx.Bool("progress") {
 				uiprogress.Start()
 			}
-			progress := newProgressor(cCtx, "tenants", len(changes)-1)
+			progress := newProgressor(cCtx, "tenants", len(changes))
 
 			var wg sync.WaitGroup
 			errChan := make(chan error, len(changes)) // buffered so it doesn't block

--- a/taskfiles/Taskfile_gobuild.yml
+++ b/taskfiles/Taskfile_gobuild.yml
@@ -22,4 +22,8 @@ tasks:
       - for: { var: GO_MOD_DIRS, as: MODULE}
         cmd: |
           cd $(dirname {{.MODULE}})
-          go build -ldflags="-s -w" -trimpath -o ./ ./...
+          VERSION=$(git describe --tags)
+          COMMIT=$(git rev-parse --short HEAD)
+          BUILDDATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          go build -ldflags="-s -w -X main.version=$VERSION -X main.commit=$COMMIT -X main.buildDate=$BUILDDATE" \
+            -trimpath -o ./ ./...

--- a/tests/ediag/ediag_test.go
+++ b/tests/ediag/ediag_test.go
@@ -12,7 +12,7 @@ import (
 // The event is provided on standard input
 func (s *EDiagSuite) TestOneEventStdIn() {
 	assert := s.Assert()
-	app := veracity.NewApp(true)
+	app := veracity.NewApp("version", true)
 	veracity.AddCommands(app, true)
 
 	// note: the suite does a before & after pipe for Stdin
@@ -31,7 +31,7 @@ func (s *EDiagSuite) TestOneEventStdIn() {
 func (s *EDiagSuite) TestOneTamperedEventStdIn() {
 
 	assert := s.Assert()
-	app := veracity.NewApp(true)
+	app := veracity.NewApp("version", true)
 	veracity.AddCommands(app, true)
 
 	// note: the suite does a before & after pipe for Stdin

--- a/tests/replicatelogs/replicatelogs_azurite_test.go
+++ b/tests/replicatelogs/replicatelogs_azurite_test.go
@@ -50,7 +50,7 @@ func (s *ReplicateLogsCmdSuite) TestReplicatingMassifLogsForOneTenant() {
 			replicaDir := s.T().TempDir()
 
 			// note: VERACITY_IKWID is set in main, we need it to enable --envauth so we force it here
-			app := veracity.NewApp(true)
+			app := veracity.NewApp("tests", true)
 			veracity.AddCommands(app, true)
 
 			err := app.Run([]string{
@@ -121,7 +121,7 @@ func (s *ReplicateLogsCmdSuite) TestSingleAncestorMassifLogsForOneTenant() {
 			replicaDir := s.T().TempDir()
 
 			// note: VERACITY_IKWID is set in main, we need it to enable --envauth so we force it here
-			app := veracity.NewApp(true)
+			app := veracity.NewApp("tests", true)
 			veracity.AddCommands(app, true)
 
 			err := app.Run([]string{
@@ -187,7 +187,7 @@ func (s *ReplicateLogsCmdSuite) TestSingleAncestorMassifsForOneTenantx() {
 	replicaDir := s.T().TempDir()
 
 	// note: VERACITY_IKWID is set in main, we need it to enable --envauth so we force it here
-	app := veracity.NewApp(true)
+	app := veracity.NewApp("tests", true)
 	veracity.AddCommands(app, true)
 
 	err := app.Run([]string{
@@ -244,7 +244,7 @@ func (s *ReplicateLogsCmdSuite) TestSparseReplicaCreatedAfterExtendedOffline() {
 	replicaDir := s.T().TempDir()
 
 	// note: VERACITY_IKWID is set in main, we need it to enable --envauth so we force it here
-	app := veracity.NewApp(true)
+	app := veracity.NewApp("tests", true)
 	veracity.AddCommands(app, true)
 
 	err := app.Run([]string{
@@ -332,7 +332,7 @@ func (s *ReplicateLogsCmdSuite) TestFullReplicaByDefault() {
 	replicaDir := s.T().TempDir()
 
 	// note: VERACITY_IKWID is set in main, we need it to enable --envauth so we force it here
-	app := veracity.NewApp(true)
+	app := veracity.NewApp("tests", true)
 	veracity.AddCommands(app, true)
 
 	err := app.Run([]string{
@@ -428,7 +428,7 @@ func (s *ReplicateLogsCmdSuite) TestLocalTamperDetected() {
 	replicaDir := s.T().TempDir()
 
 	// note: VERACITY_IKWID is set in main, we need it to enable --envauth so we force it here
-	app := veracity.NewApp(true)
+	app := veracity.NewApp("tests", true)
 	veracity.AddCommands(app, true)
 
 	err := app.Run([]string{
@@ -544,7 +544,7 @@ func (s *ReplicateLogsCmdSuite) Test4MassifsForThreeTenants() {
 	replicaDir := s.T().TempDir()
 
 	// note: VERACITY_IKWID is set in main, we need it to enable --envauth so we force it here
-	app := veracity.NewApp(true)
+	app := veracity.NewApp("tests", true)
 	veracity.AddCommands(app, true)
 
 	err = app.Run([]string{
@@ -635,7 +635,7 @@ func (s *ReplicateLogsCmdSuite) Test4MassifsForThreeTenantsFromFile() {
 	createFileFromData(s.T(), data, inputFilename)
 
 	// note: VERACITY_IKWID is set in main, we need it to enable --envauth so we force it here
-	app := veracity.NewApp(true)
+	app := veracity.NewApp("tests", true)
 	veracity.AddCommands(app, true)
 
 	err = app.Run([]string{

--- a/tests/replicatelogs/replicatelogs_prod_test.go
+++ b/tests/replicatelogs/replicatelogs_prod_test.go
@@ -15,7 +15,7 @@ func (s *ReplicateLogsCmdSuite) TestReplicateFirstPublicMassif() {
 	replicaDir := s.T().TempDir()
 
 	// NOTE: These will fail in the CI until the prod APIM principal gets the new custom role
-	app := veracity.NewApp(false)
+	app := veracity.NewApp("tests", false)
 	veracity.AddCommands(app, false)
 
 	err := app.Run([]string{
@@ -24,7 +24,8 @@ func (s *ReplicateLogsCmdSuite) TestReplicateFirstPublicMassif() {
 		"--tenant", s.Env.PublicTenantId,
 		"replicate-logs",
 		"--replicadir", replicaDir,
-		"--massif", "0",
+		"--progress",
+		"--massif", "1",
 	})
 	s.NoError(err)
 

--- a/tests/systemtest/test.sh
+++ b/tests/systemtest/test.sh
@@ -60,8 +60,11 @@ testVeracityVersion() {
     output=$($VERACITY_INSTALL --version)
     assertEquals "veracity --version should return a 0 exit code" 0 $?
 
-    [[ "$output" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]
-    assertTrue "The output should start with a semantic version string" $?
+    if [[ "$output" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+        echo "veracity version: $output"
+    else
+        fail "The output should start with a semantic version string"
+    fi 
 }
 
 testVeracityWatchPublicFindsActivity() {

--- a/tests/systemtest/test.sh
+++ b/tests/systemtest/test.sh
@@ -55,6 +55,15 @@ assertStringMatch() {
     assertEquals "$message" "$expected" "$actual"
 }
 
+testVeracityVersion() {
+    local output
+    output=$($VERACITY_INSTALL --version)
+    assertEquals "veracity --version should return a 0 exit code" 0 $?
+
+    [[ "$output" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]
+    assertTrue "The output should start with a semantic version string" $?
+}
+
 testVeracityWatchPublicFindsActivity() {
     local output
     output=$($VERACITY_INSTALL --data-url $DATATRAILS_URL/verifiabledata --tenant=$PROD_PUBLIC_TENANT_ID watch --horizon 10000h)

--- a/tests/systemtest/test.sh
+++ b/tests/systemtest/test.sh
@@ -60,11 +60,8 @@ testVeracityVersion() {
     output=$($VERACITY_INSTALL --version)
     assertEquals "veracity --version should return a 0 exit code" 0 $?
 
-    if [[ "$output" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-        echo "veracity version: $output"
-    else
-        fail "The output should start with a semantic version string"
-    fi 
+    echo "$output" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+'
+    assertTrue "The output should start with a semantic version string" $?  
 }
 
 testVeracityWatchPublicFindsActivity() {

--- a/tests/verifyincluded/verifyevents_test.go
+++ b/tests/verifyincluded/verifyevents_test.go
@@ -12,7 +12,7 @@ import (
 // The event is provided on standard input
 func (s *VerifyEventsSuite) TestVerifyOneEventStdIn() {
 	assert := s.Assert()
-	app := veracity.NewApp(true)
+	app := veracity.NewApp("version", true)
 	veracity.AddCommands(app, true)
 
 	// note: the suite does a before & after pipe for Stdin
@@ -31,7 +31,7 @@ func (s *VerifyEventsSuite) TestVerifyOneEventStdIn() {
 func (s *VerifyEventsSuite) TestOneTamperEventStdIn() {
 
 	assert := s.Assert()
-	app := veracity.NewApp(true)
+	app := veracity.NewApp("version", true)
 	veracity.AddCommands(app, true)
 
 	// note: the suite does a before & after pipe for Stdin

--- a/tests/watch/watch_test.go
+++ b/tests/watch/watch_test.go
@@ -8,7 +8,7 @@ import (
 
 func (s *WatchCmdSuite) TestNoErrorOrNoChanges() {
 
-	app := veracity.NewApp(false)
+	app := veracity.NewApp("version", false)
 	veracity.AddCommands(app, false)
 
 	err := app.Run([]string{
@@ -24,7 +24,7 @@ func (s *WatchCmdSuite) TestNoErrorOrNoChanges() {
 // The watch command does not check wether the tenants to "filter" for actually have logs
 func (s *WatchCmdSuite) TestNoChangesForFictitiousTenant() {
 	assert := s.Assert()
-	app := veracity.NewApp(false)
+	app := veracity.NewApp("version", false)
 	veracity.AddCommands(app, false)
 	err := app.Run([]string{
 		"veracity",
@@ -39,7 +39,7 @@ func (s *WatchCmdSuite) TestNoChangesForFictitiousTenant() {
 func (s *WatchCmdSuite) TestReplicateFirstPublicMassif() {
 
 	// NOTE: These will fail in the CI until the prod APIM principal gets the new custom role
-	app := veracity.NewApp(false)
+	app := veracity.NewApp("version", false)
 	veracity.AddCommands(app, false)
 
 	err := app.Run([]string{

--- a/tests/watch/watch_test.go
+++ b/tests/watch/watch_test.go
@@ -35,8 +35,8 @@ func (s *WatchCmdSuite) TestNoChangesForFictitiousTenant() {
 	assert.Equal(err, veracity.ErrNoChanges)
 }
 
-// Test that the watch command returns no error or that the error is "no changes"
-func (s *WatchCmdSuite) TestReplicateFirstPublicMassif() {
+// Test that the watch command returns no error when the horizon is set longer than the age of the company
+func (s *WatchCmdSuite) TestChangesDetected() {
 
 	// NOTE: These will fail in the CI until the prod APIM principal gets the new custom role
 	app := veracity.NewApp("version", false)


### PR DESCRIPTION

<img width="798" alt="Screenshot 2024-09-13 at 09 40 55" src="https://github.com/user-attachments/assets/3073216f-eb5a-4d20-8d34-879d525ecc6c">
This change adds:
* --version support
* replicatelogs --progress Which enables a progress meter for replicatelogs
A bunch of files needed to deal with passing in the version string to NewApp, that makes this look a lot more significant than it is.

progress.go and replicatelogs.go are the things to focus on and the single additional test in tests.sh