### PR TITLE
enable release of veracity ahead of production v1 seals

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/datatrails/go-datatrails-common v0.18.0
 	github.com/datatrails/go-datatrails-common-api-gen v0.4.6
 	github.com/datatrails/go-datatrails-logverification v0.2.0
-	github.com/datatrails/go-datatrails-merklelog/massifs v0.2.1
+	github.com/datatrails/go-datatrails-merklelog/massifs v0.2.2
 	github.com/datatrails/go-datatrails-merklelog/mmr v0.1.1
 	github.com/datatrails/go-datatrails-merklelog/mmrtesting v0.1.0
 	github.com/datatrails/go-datatrails-simplehash v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,8 @@ github.com/datatrails/go-datatrails-common-api-gen v0.4.6 h1:yzviWC2jBOC3ItotQQl
 github.com/datatrails/go-datatrails-common-api-gen v0.4.6/go.mod h1:OQN91xvlW6xcWTFvwsM2Nn4PZwFAIOE52FG7yRl4QPQ=
 github.com/datatrails/go-datatrails-logverification v0.2.0 h1:CzCSGw1Sn1KUd/X32atSk9PTQpl8QBS5BXn+hPwpwmI=
 github.com/datatrails/go-datatrails-logverification v0.2.0/go.mod h1:hu+VUZOvkPIHlhp1+qTELNozgsdvlENbXDzt/6Kcoc8=
-github.com/datatrails/go-datatrails-merklelog/massifs v0.2.1 h1:yTJECUNlVJSvSrAV6BVOBtyakAzbBBqLU+rhZrKWI7Y=
-github.com/datatrails/go-datatrails-merklelog/massifs v0.2.1/go.mod h1:3V08x15NPbzBTSrvjvgzUA0ADkxBRV7m3p5ODElmB2A=
+github.com/datatrails/go-datatrails-merklelog/massifs v0.2.2 h1:zxrwrDV8JI7SpBIJxpEJgDERhIilLFr23QSYJak+Zx4=
+github.com/datatrails/go-datatrails-merklelog/massifs v0.2.2/go.mod h1:3V08x15NPbzBTSrvjvgzUA0ADkxBRV7m3p5ODElmB2A=
 github.com/datatrails/go-datatrails-merklelog/mmr v0.1.1 h1:Ro2fYdDYxGGcPmudYuvPonx78GkdQuKwzrdknLR55cE=
 github.com/datatrails/go-datatrails-merklelog/mmr v0.1.1/go.mod h1:B/Kkz4joZTiTz0q/9FFAgHR+Tcn6UxtphMuCzamAc9Q=
 github.com/datatrails/go-datatrails-merklelog/mmrtesting v0.1.0 h1:q9RXtAGydXKSJjARnFObNu743cbfIOfERTXiiVa2tF4=

--- a/replicatelogs.go
+++ b/replicatelogs.go
@@ -608,7 +608,7 @@ func verifiedStateEqual(a *massifs.VerifiedContext, b *massifs.VerifiedContext) 
 	if len(fromRoots) != len(toRoots) {
 		return false
 	}
-	for i := 0; i < len(fromRoots); i++ {
+	for i := range len(fromRoots) {
 		if !bytes.Equal(fromRoots[i], toRoots[i]) {
 			return false
 		}

--- a/replicatelogs.go
+++ b/replicatelogs.go
@@ -396,11 +396,12 @@ func (v *VerifiedReplica) ReplicateVerifiedUpdates(
 			return local.MMRState, nil
 		}
 
-		// Ok, production case. We need to promote the legacy base state to a V1
-		// state for the consistency check.  This is a one way operation, and
-		// the legacy seal root is discarded.  Once the seal for the open massif
-		// is upgraded, this case will never be encountered again for that
-		// tenant.
+		// At this point we have a local seal in v0 format and we expect the
+		// remote seal to be in v1 format (post v1 seal release for avid + forestrie).
+		// We need to promote the legacy base state to a V1 state for the
+		// consistency check.  This is a one way operation, and the legacy seal
+		// root is discarded.  Once the seal for the open massif is upgraded,
+		// this case will never be encountered again for that tenant.
 
 		peaks, err := mmr.PeakHashes(local, local.MMRState.MMRSize-1)
 		if err != nil {

--- a/tests/replicatelogs/replicatelogs_azurite_test.go
+++ b/tests/replicatelogs/replicatelogs_azurite_test.go
@@ -108,12 +108,11 @@ func (s *ReplicateLogsCmdSuite) TestV0ToV1ReplicationTransition() {
 			if lastMassif > 0 {
 				massifLeaves := mmr.HeightIndexLeafCount(uint64(tt.massifHeight - 1)) // = ((2 << massifHeight) - 1 + 1) >> 1
 				// CreateLog always deleted blobs, so we can only use AddLeavesToLog here
-				for i := uint64(0); i < tt.v1Count; i++ {
+				for range tt.v1Count {
 					tc.AddLeavesToLog(
 						tenantId0, tt.massifHeight, int(massifLeaves),
 						massifs.TestWithSealKey(&key), /*, massifs.TestWithV0Seals() V1 seals*/
 					)
-
 				}
 			}
 			if tt.lastLeagacyLeafCount > 0 {


### PR DESCRIPTION
We need to release veracity ahead of the deployment of the scitt & receipt updates.

To do so the released veracity, with v1 seal support, must be able to continue to replicate v0 sealed logs. 