### PR TITLE
fix: horizon commanline option parse issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,5 +198,6 @@ Additional Commands include:
 * `watch` - discover recently active logs
 * `replicate-logs` - create or update a local trusted replica of one more more tenants logs,
    accepts the output of `watch` as input.
+* `receipt` - Generate a [COSE Receipt](https://www.ietf.org/archive/id/draft-ietf-cose-merkle-tree-proofs-07.html) of inclusion using the [MMRIVER profile](https://www.ietf.org/archive/id/draft-bryce-cose-merkle-mountain-range-proofs-00.html) for an entry.
 
 For more information, please visit the [DataTrails documentation](https://docs.datatrails.ai/)

--- a/tests/systemtest/test.sh
+++ b/tests/systemtest/test.sh
@@ -71,6 +71,13 @@ testVeracityWatchPublicFindsActivity() {
     assertContains "watch-public should find activity" "$output" "$PROD_PUBLIC_TENANT_ID"
 }
 
+testVeracityWatchLatestFindsActivity() {
+    local output
+    output=$($VERACITY_INSTALL --data-url $DATATRAILS_URL/verifiabledata --tenant=$PROD_PUBLIC_TENANT_ID watch --latest)
+    assertEquals "watch-public --latest should return a 0 exit code" 0 $?
+    assertContains "watch-public --latest should find activity" "$output" "$PROD_PUBLIC_TENANT_ID"
+}
+
 testVeracityReplicateLogsPublicTenantWatchPipe() {
     local output
 

--- a/tests/watch/watch_test.go
+++ b/tests/watch/watch_test.go
@@ -18,11 +18,9 @@ func (s *WatchCmdSuite) TestErrorForNegativeHorizon() {
 		"--horizon", "-1h",
 	})
 	s.ErrorContains(err, "negative horizon")
-	// alternative approach which just makes the error more readable
-	// s.ErrorContains(err, "is to large or otherwise out of range")
 }
 
-func (s *WatchCmdSuite) TestNoErrorVeryLargeHorizon() {
+func (s *WatchCmdSuite) TestErrorGuidanceForVeryLargeHorizon() {
 
 	app := veracity.NewApp("version", false)
 	veracity.AddCommands(app, false)
@@ -32,14 +30,12 @@ func (s *WatchCmdSuite) TestNoErrorVeryLargeHorizon() {
 		"--data-url", s.Env.VerifiableDataURL,
 		"watch",
 		"--horizon", "1000000000h",
-		//"--horizon", "100000h", // 11 years, so we are sure we look back far enough to find an event
 	})
-	s.NoError(err)
-	// alternative approach which just makes the error more readable
-	// s.ErrorContains(err, "is out of range or otherwise invalid")
+	s.ErrorContains(err, "--horizon=max")
+	s.ErrorContains(err, "--latest")
 }
 
-func (s *WatchCmdSuite) TestNoErrorLargeButParsableHorizon() {
+func (s *WatchCmdSuite) TestErrorGuidanceForLargeButParsableHorizon() {
 
 	app := veracity.NewApp("version", false)
 	veracity.AddCommands(app, false)
@@ -50,9 +46,8 @@ func (s *WatchCmdSuite) TestNoErrorLargeButParsableHorizon() {
 		"watch",
 		"--horizon", "1000000h", // over flows the id timestamp epoch
 	})
-	s.NoError(err)
-	// alternative approach which just makes the error more readable
-	// s.ErrorContains(err, "is out of range or otherwise invalid")
+	s.ErrorContains(err, "--horizon=max")
+	s.ErrorContains(err, "--latest")
 }
 
 func (s *WatchCmdSuite) TestNoErrorOrNoChanges() {
@@ -79,7 +74,7 @@ func (s *WatchCmdSuite) TestNoChangesForFictitiousTenant() {
 		"veracity",
 		"--data-url", s.Env.VerifiableDataURL,
 		"--tenant", s.Env.UnknownTenantId,
-		"watch",
+		"watch", "--latest",
 	})
 	assert.Equal(err, veracity.ErrNoChanges)
 }

--- a/tests/watch/watch_test.go
+++ b/tests/watch/watch_test.go
@@ -6,6 +6,55 @@ import (
 	"github.com/datatrails/veracity"
 )
 
+func (s *WatchCmdSuite) TestErrorForNegativeHorizon() {
+
+	app := veracity.NewApp("version", false)
+	veracity.AddCommands(app, false)
+
+	err := app.Run([]string{
+		"veracity",
+		"--data-url", s.Env.VerifiableDataURL,
+		"watch",
+		"--horizon", "-1h",
+	})
+	s.ErrorContains(err, "negative horizon")
+	// alternative approach which just makes the error more readable
+	// s.ErrorContains(err, "is to large or otherwise out of range")
+}
+
+func (s *WatchCmdSuite) TestNoErrorVeryLargeHorizon() {
+
+	app := veracity.NewApp("version", false)
+	veracity.AddCommands(app, false)
+
+	err := app.Run([]string{
+		"veracity",
+		"--data-url", s.Env.VerifiableDataURL,
+		"watch",
+		"--horizon", "1000000000h",
+		//"--horizon", "100000h", // 11 years, so we are sure we look back far enough to find an event
+	})
+	s.NoError(err)
+	// alternative approach which just makes the error more readable
+	// s.ErrorContains(err, "is out of range or otherwise invalid")
+}
+
+func (s *WatchCmdSuite) TestNoErrorLargeButParsableHorizon() {
+
+	app := veracity.NewApp("version", false)
+	veracity.AddCommands(app, false)
+
+	err := app.Run([]string{
+		"veracity",
+		"--data-url", s.Env.VerifiableDataURL,
+		"watch",
+		"--horizon", "1000000h", // over flows the id timestamp epoch
+	})
+	s.NoError(err)
+	// alternative approach which just makes the error more readable
+	// s.ErrorContains(err, "is out of range or otherwise invalid")
+}
+
 func (s *WatchCmdSuite) TestNoErrorOrNoChanges() {
 
 	app := veracity.NewApp("version", false)

--- a/watch.go
+++ b/watch.go
@@ -106,7 +106,7 @@ func NewLogWatcherCmd() *cli.Command {
 			cmd := &CmdCtx{}
 			ctx := context.Background()
 
-			if err := cfgLogging(cmd, cCtx); err != nil {
+			if err = cfgLogging(cmd, cCtx); err != nil {
 				return err
 			}
 			reporter := &defaultReporter{log: cmd.log}

--- a/watch.go
+++ b/watch.go
@@ -185,7 +185,7 @@ func parseHorizon(horizon string) (time.Duration, error) {
 	if err == nil {
 
 		if d > maxHorizon {
-			return maxHorizon, fmt.Errorf("the maximum supported duration is --horizon=%v, which has the alias --horizon=max. also consider using --latest", maxHorizon)
+			return 0, fmt.Errorf("the maximum supported duration is --horizon=%v, which has the alias --horizon=max. also consider using --latest", maxHorizon)
 		}
 		if d < 0 {
 			return 0, fmt.Errorf("negative horizon value:%s", horizon)
@@ -195,7 +195,7 @@ func parseHorizon(horizon string) (time.Duration, error) {
 	}
 
 	if strings.HasPrefix(err.Error(), rangeDurationParseErrorSubString) {
-		return maxHorizon, fmt.Errorf("the supplied horizon was invalid. the maximum supported duration is --horizon=%v, which has the alias --horizon=max. also consider using --latest", maxHorizon)
+		return 0, fmt.Errorf("the supplied horizon was invalid. the maximum supported duration is --horizon=%v, which has the alias --horizon=max. also consider using --latest", maxHorizon)
 	}
 
 	return d, fmt.Errorf("the horizon '%s' is out of range or otherwise invalid. Use --horizon=max to get the largest supported value %v. also consider using --latest", horizon, maxHorizon)

--- a/watch.go
+++ b/watch.go
@@ -83,7 +83,7 @@ func NewLogWatcherCmd() *cli.Command {
 			&cli.StringFlag{
 				Name:    "horizon",
 				Aliases: []string{"z"},
-				Value:   "24s",
+				Value:   "24h",
 				Usage:   "Infer since as now - horizon. The format is {number}{units} eg 1h to only see things in the last hour. If watching (count=0), since is re-calculated every interval",
 			},
 			&cli.DurationFlag{

--- a/watch_test.go
+++ b/watch_test.go
@@ -143,7 +143,7 @@ func TestNewWatchConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewWatchConfig(tt.args.cCtx, tt.args.cmd)
+			got, err := NewWatchConfig(tt.args.cCtx, tt.args.cmd, &mockReporter{})
 			if err != nil {
 				if tt.errPrefix == "" {
 					t.Errorf("NewWatchConfig() unexpected error = %v", err)


### PR DESCRIPTION
* explicitly error for negative horizons
* clamp to avoid over flowing idtimestamp arithmetic
* force to largest supported value for range errors, this is fail safe.
* add alias for max value on horizon
* add --latest option to remove the need for the common "latest changes" to use --horizon and --idsince