### PR TITLE
Dev/robin/10146 make v1seals the default

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/datatrails/go-datatrails-common v0.18.0
 	github.com/datatrails/go-datatrails-common-api-gen v0.4.6
 	github.com/datatrails/go-datatrails-logverification v0.2.0
-	github.com/datatrails/go-datatrails-merklelog/massifs v0.2.2
+	github.com/datatrails/go-datatrails-merklelog/massifs v0.2.3
 	github.com/datatrails/go-datatrails-merklelog/mmr v0.1.1
 	github.com/datatrails/go-datatrails-merklelog/mmrtesting v0.1.0
 	github.com/datatrails/go-datatrails-simplehash v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,8 @@ github.com/datatrails/go-datatrails-common-api-gen v0.4.6 h1:yzviWC2jBOC3ItotQQl
 github.com/datatrails/go-datatrails-common-api-gen v0.4.6/go.mod h1:OQN91xvlW6xcWTFvwsM2Nn4PZwFAIOE52FG7yRl4QPQ=
 github.com/datatrails/go-datatrails-logverification v0.2.0 h1:CzCSGw1Sn1KUd/X32atSk9PTQpl8QBS5BXn+hPwpwmI=
 github.com/datatrails/go-datatrails-logverification v0.2.0/go.mod h1:hu+VUZOvkPIHlhp1+qTELNozgsdvlENbXDzt/6Kcoc8=
-github.com/datatrails/go-datatrails-merklelog/massifs v0.2.2 h1:zxrwrDV8JI7SpBIJxpEJgDERhIilLFr23QSYJak+Zx4=
-github.com/datatrails/go-datatrails-merklelog/massifs v0.2.2/go.mod h1:3V08x15NPbzBTSrvjvgzUA0ADkxBRV7m3p5ODElmB2A=
+github.com/datatrails/go-datatrails-merklelog/massifs v0.2.3 h1:rDD52aYlI/sqti9JuRWYbPxmyroZ94bu42AnZgoUfAw=
+github.com/datatrails/go-datatrails-merklelog/massifs v0.2.3/go.mod h1:3V08x15NPbzBTSrvjvgzUA0ADkxBRV7m3p5ODElmB2A=
 github.com/datatrails/go-datatrails-merklelog/mmr v0.1.1 h1:Ro2fYdDYxGGcPmudYuvPonx78GkdQuKwzrdknLR55cE=
 github.com/datatrails/go-datatrails-merklelog/mmr v0.1.1/go.mod h1:B/Kkz4joZTiTz0q/9FFAgHR+Tcn6UxtphMuCzamAc9Q=
 github.com/datatrails/go-datatrails-merklelog/mmrtesting v0.1.0 h1:q9RXtAGydXKSJjARnFObNu743cbfIOfERTXiiVa2tF4=

--- a/localwriter.go
+++ b/localwriter.go
@@ -9,15 +9,23 @@ import (
 )
 
 // FileWriteAppendOpener is an interface for opening a file for writing
-// if the file exists, it is opened in APPEND mode
+// The Open implementation must  open for *append*, and must create the file if it does not exist.
+// The Create implementation must truncate the file if it exists, and create it if it does not.
 type FileWriteAppendOpener struct{}
 
+// Open ensures the named file exists and is writable. Writes are appended to any existing content.
 func (*FileWriteAppendOpener) Open(name string) (io.WriteCloser, error) {
 	name, err := filepath.Abs(name)
 	if err != nil {
 		return nil, err
 	}
 	return os.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+}
+
+// Create ensures the named file exists, is empty and is writable
+// If the named file already exists it is truncated
+func (*FileWriteAppendOpener) Create(name string) (io.WriteCloser, error) {
+	return os.Create(name)
 }
 
 func NewFileWriteOpener() massifs.WriteAppendOpener {

--- a/replicatelogs.go
+++ b/replicatelogs.go
@@ -47,10 +47,6 @@ func NewReplicateLogsCmd() *cli.Command {
 		Usage:   `verifies the remote log and replicates it locally, ensuring the remote changes are consistent with the trusted local replica.`,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{Name: skipUncommittedFlagName, Value: false},
-			&cli.BoolFlag{
-				Name: "enable-v1seals", Value: false,
-				Usage: "Set to enable pre-release suport for the new V1 seal format. Once the new format is in production, this flag will be removed.",
-			},
 			&cli.IntFlag{
 				Name: "massif", Aliases: []string{"m"},
 			},
@@ -373,31 +369,15 @@ func (v *VerifiedReplica) ReplicateVerifiedUpdates(
 		return false
 	}
 
-	remoteOptionsFromLocal := func(local *massifs.VerifiedContext) []massifs.ReaderOption {
-		var opts []massifs.ReaderOption
-		if local == nil {
-			return opts
-		}
-
-		return append(opts, massifs.WithTrustedBaseState(local.MMRState))
-	}
-
 	// on demand promotion of a v0 state to a v1 state, for compatibility with the consistency check.
 	trustedBaseState := func(local *massifs.VerifiedContext) (massifs.MMRState, error) {
 
 		if local.MMRState.Version > int(massifs.MMRStateVersion0) {
-			// this will just work, until v1 seals reach production no customer can encounter this.
-			return local.MMRState, nil
-		}
-
-		if !v.cCtx.Bool("enable-v1seals") {
-			// The user has not explictly enabled the new seal format, so we return the legacy state unchanged.
-			// THis will "just work" for production. Use against a pre-release endpoint will fail verification.
 			return local.MMRState, nil
 		}
 
 		// At this point we have a local seal in v0 format and we expect the
-		// remote seal to be in v1 format (post v1 seal release for avid + forestrie).
+		// remote seal to be in v1 format.
 		// We need to promote the legacy base state to a V1 state for the
 		// consistency check.  This is a one way operation, and the legacy seal
 		// root is discarded.  Once the seal for the open massif is upgraded,
@@ -475,6 +455,7 @@ func (v *VerifiedReplica) ReplicateVerifiedUpdates(
 
 	for i := startMassif; i <= endMassif; i++ {
 
+		remoteVerifyOpts := []massifs.ReaderOption{massifs.WithCBORCodec(v.cborCodec)}
 		if local != nil {
 			// Promote the trusted base state to a V1 state if it is a V0 state.
 			// All currently incomplete massifs in remote replicas will have their
@@ -482,10 +463,12 @@ func (v *VerifiedReplica) ReplicateVerifiedUpdates(
 			// completed massifs will remain as V0 seals.  Atempting to replicate a
 			// V0 state will fail with a suitable error. That just implies the
 			// veracity tool has been run against a legacy endpoint.
-			local.MMRState, err = trustedBaseState(local)
+			baseState, err := trustedBaseState(local)
 			if err != nil {
 				return err
 			}
+			// The local seal stays in v0 format until the end of the massif, else we break the signature
+			remoteVerifyOpts = append(remoteVerifyOpts, massifs.WithTrustedBaseState(baseState))
 		}
 
 		// On the first iteration local is *either* the predecessor to
@@ -494,8 +477,7 @@ func (v *VerifiedReplica) ReplicateVerifiedUpdates(
 		// remote is still incomplte it means there is no subseqent massif to
 		// read)
 		remote, err := v.remoteReader.GetVerifiedContext(
-			ctx, tenantIdentity, uint64(i),
-			append(remoteOptionsFromLocal(local), massifs.WithCBORCodec(v.cborCodec))...)
+			ctx, tenantIdentity, uint64(i), remoteVerifyOpts...)
 		if err != nil {
 			// both the remote massif and it's seal must be present for the
 			// verification to succeed, so we don't filter using isBlobNotFound


### PR DESCRIPTION
feat: remove the transitional --enable-v1seals flag, they are now enabled by default. no user action required.
fix: take the fix for local log corruption issue, files were opened append when the should have been opened create|trunc Re #10163