### PR TITLE
Dev/jgough/find trie entries

### DIFF
--- a/app.go
+++ b/app.go
@@ -64,6 +64,7 @@ func AddCommands(app *cli.App, ikwid bool) *cli.App {
 		app.Commands = append(app.Commands, NewEventDiagCmd())
 		app.Commands = append(app.Commands, NewDiagCmd())
 		app.Commands = append(app.Commands, NewNodeScanCmd())
+		app.Commands = append(app.Commands, NewFindTrieEntriesCmd())
 	}
 	return app
 }

--- a/findtrieentries.go
+++ b/findtrieentries.go
@@ -93,7 +93,7 @@ func findTrieKeys(log logger.Logger, massifReader MassifReader, logTenant string
 
 		log.Debugf("checking %v trie entries in massif %v for matches", trieEntries, massifIndex)
 
-		// check each leaf for matching trieKeys
+		// check each trie entry for matching trieKeys
 		for range trieEntries {
 
 			mmrIndex := mmr.MMRIndex(trieIndex)
@@ -118,7 +118,7 @@ func findTrieKeys(log logger.Logger, massifReader MassifReader, logTenant string
 		}
 	}
 
-	// the leaf index is now the leaf size as we do an extra +1 at the end of the for loop
+	// the trie index is now the trie size as we do an extra +1 at the end of the for loop
 	return matchingTrieIndexes, trieIndex, nil
 
 }
@@ -134,6 +134,8 @@ func NewFindTrieEntriesCmd() *cli.Command {
 		By default returns all trie Indexes (leaf indexes) of matching trie entries.
 
 		The trieKey is HASH(DOMAIN | LOGID | APPID)
+
+		NOTE: ignores the global --tenant option, please use --log-tenant command option.
 `,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
@@ -164,13 +166,8 @@ func NewFindTrieEntriesCmd() *cli.Command {
 			cmd := &CmdCtx{}
 
 			// This command uses the structured logger for all optional output.
-			// Output not explicitly printed is silenced by default.
 			if err := cfgLogging(cmd, cCtx); err != nil {
 				return err
-			}
-
-			log := func(m string, args ...any) {
-				cmd.log.Infof(m, args...)
 			}
 
 			// get all flags
@@ -278,7 +275,7 @@ func NewFindTrieEntriesCmd() *cli.Command {
 
 			// if we want the trie index matches log them and return
 			if !asMMRIndexes {
-				log("matches: %v", trieIndexMatches)
+				fmt.Printf("matches: %v\n", trieIndexMatches)
 				return nil
 			}
 
@@ -290,7 +287,7 @@ func NewFindTrieEntriesCmd() *cli.Command {
 				mmrIndexMatches = append(mmrIndexMatches, mmrIndex)
 			}
 
-			log("matches: %v", mmrIndexMatches)
+			fmt.Printf("matches: %v\n", mmrIndexMatches)
 
 			return nil
 

--- a/findtrieentries.go
+++ b/findtrieentries.go
@@ -100,6 +100,7 @@ func findTrieKeys(log logger.Logger, massifReader MassifReader, logTenant string
 	leafIndex := uint64(massifStartIndex * int64(mmr.HeightIndexLeafCount(uint64(massifHeight-1))))
 
 	matchingLeafIndexes := []uint64{}
+	entriesConsidered := uint64(0)
 
 	// search all massifs from the starting index to the end index
 	for massifIndex := massifStartIndex; massifIndex <= massifEndIndex; massifIndex++ {
@@ -137,12 +138,12 @@ func findTrieKeys(log logger.Logger, massifReader MassifReader, logTenant string
 			}
 
 			leafIndex++
+			entriesConsidered++
 
 		}
 	}
 
-	// the leaf index is now the leaf size as we do an extra +1 at the end of the for loop
-	return matchingLeafIndexes, leafIndex, nil
+	return matchingLeafIndexes, entriesConsidered, nil
 
 }
 

--- a/findtrieentries.go
+++ b/findtrieentries.go
@@ -1,0 +1,286 @@
+package veracity
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/datatrails/go-datatrails-merklelog/massifs"
+	"github.com/datatrails/go-datatrails-merklelog/mmr"
+	"github.com/google/uuid"
+	"github.com/urfave/cli/v2"
+)
+
+/**
+ * find trie Entries finds the trie entry associated with a given trie key
+ */
+
+const (
+	logTenantFlagName = "log-tenant"
+
+	logIDFlagName = "log-id"
+
+	domainFlagName = "domain"
+
+	appIDFlagName = "app-id"
+
+	asMMRIndexesFlagName = "as-mmrindexes"
+)
+
+var (
+	ErrNoLogTenant = fmt.Errorf("error, cannot find log tenant, please provide either %v or %v", logIDFlagName, logTenantFlagName)
+)
+
+// logIDToLogTenant converts the log id to the log tenant
+func logIDToLogTenant(logID string) (string, error) {
+
+	// first get the byte representation of the hex
+	logIdBytes, err := hex.DecodeString(logID)
+	if err != nil {
+		return "", err
+	}
+
+	// we don't know if its a log version 0 log id or a log version 1 log id
+
+	// attempt log version 1 first
+
+	// log version 1 is the byte representation of the uuid part of the log tenant
+	logIdUUid, err := uuid.ParseBytes(logIdBytes)
+	if err != nil {
+
+		// assume its log version 0 if it can't be parsed as bytes
+		// which is just utf-8 bytes of the log tenant string
+		return string(logIdBytes), nil
+	}
+
+	// if we get here we know its log version 1, so make the log tenant from the uuid
+	logTenant := fmt.Sprintf("tenant/%s", logIdUUid.String())
+
+	return logTenant, nil
+}
+
+// findTrieKeys searchs the log of the given log tenant for matches to the given triekeys
+// and returns the trie indexes (leaf indexes) of all the matches
+func findTrieKeys(massifReader MassifReader, logTenant string, trieKeys ...[]byte) ([]uint64, error) {
+
+	// get the head massif
+	headMassifContext, err := massifReader.GetHeadMassif(context.Background(), logTenant)
+	if err != nil {
+		return nil, err
+	}
+
+	// find the number of massifs
+	massifCount := headMassifContext.Start.MassifIndex + 1
+
+	leafIndex := uint64(0)
+
+	matchingTrieIndexes := []uint64{}
+
+	for massifIndex := range massifCount {
+
+		massifContext, err := massifReader.GetMassif(context.Background(), logTenant, uint64(massifIndex))
+		if err != nil {
+			return nil, err
+		}
+
+		// get the leaf count based on the size
+		massifLeaves := massifContext.MassifLeafCount()
+
+		// check each leaf for matching trieKeys
+		for range massifLeaves {
+
+			mmrIndex := mmr.MMRIndex(leafIndex)
+
+			logTrieKey, err := massifContext.GetTrieKey(mmrIndex)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, trieKey := range trieKeys {
+
+				// if a triekey matches add it to the matching trie indexes
+				// NOTE: the leaf index and trie index are equivilent.
+				if bytes.Equal(trieKey, logTrieKey) {
+					matchingTrieIndexes = append(matchingTrieIndexes, leafIndex)
+					break // only one trieKey will ever match, so if we found the matching trie key, don't keep looking
+				}
+
+			}
+
+			leafIndex++
+
+		}
+
+	}
+
+	return matchingTrieIndexes, nil
+
+}
+
+// NewFindTrieEntriesCmd finds the trie entries associated with a given trie key in the tenants Merkle Log.
+//
+//nolint:gocognit
+func NewFindTrieEntriesCmd() *cli.Command {
+	return &cli.Command{
+		Name: "find-trie-entries",
+		Usage: `finds the matching trie entries for the given trie key.
+
+		By default returns all trie Indexes (leaf indexes) of matching trie entries.
+
+		The trieKey is HASH(DOMAIN | LOGID | APPID)
+`,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  logTenantFlagName,
+				Usage: fmt.Sprintf("the tenant of the log to search in. Required or can be derived from %v.", logIDFlagName),
+			},
+			&cli.StringFlag{
+				Name:  logIDFlagName,
+				Usage: fmt.Sprintf("the hexadecimal representation of the log ID. Required or can be derived from %v.", logTenantFlagName),
+			},
+			&cli.StringFlag{
+				Name:     appIDFlagName,
+				Usage:    "the app ID. For eventsv1 or assetsv2 this is the event id.",
+				Required: true,
+			},
+			&cli.Uint64Flag{
+				Name:  domainFlagName,
+				Usage: "the domain used to derive the trie key.",
+				Value: uint64(massifs.KeyTypeApplicationContent),
+			},
+			&cli.BoolFlag{
+				Name:  asMMRIndexesFlagName,
+				Usage: "if true, returns a list of matching mmr indexes instead of trie indexes.",
+				Value: false,
+			},
+		},
+		Action: func(cCtx *cli.Context) error {
+			cmd := &CmdCtx{}
+
+			// This command uses the structured logger for all optional output.
+			// Output not explicitly printed is silenced by default.
+			if err := cfgLogging(cmd, cCtx); err != nil {
+				return err
+			}
+
+			log := func(m string, args ...any) {
+				cmd.log.Infof(m, args...)
+			}
+
+			// get all flags
+			logTenant := cCtx.String(logTenantFlagName)
+			logID := cCtx.String(logIDFlagName)
+
+			appID := cCtx.String(appIDFlagName)
+
+			domain := cCtx.Uint64(domainFlagName)
+
+			asMMRIndexes := cCtx.Bool(asMMRIndexesFlagName)
+
+			// check we only have at least 1 of log tenant or logID
+			if logTenant == "" && logID == "" {
+				return ErrNoLogTenant
+			}
+
+			// if we don't have the log tenant derive it from the
+			//  log id
+			if logTenant == "" {
+				var err error
+				logTenant, err = logIDToLogTenant(logID)
+				if err != nil {
+					return err
+				}
+			}
+
+			// configure the cmd massif reader
+			if err := cfgMassifReader(cmd, cCtx); err != nil {
+				return err
+			}
+
+			trieIndexMatches := []uint64{}
+
+			// if we have the logID use it to find the trie key.
+			if logID != "" {
+
+				logIDBytes, err := hex.DecodeString(logID)
+				if err != nil {
+					return err
+				}
+
+				trieKey := massifs.NewTrieKey(
+					massifs.KeyType(domain),
+					logIDBytes,
+					[]byte(appID),
+				)
+
+				trieIndexMatches, err = findTrieKeys(cmd.massifReader, logTenant, trieKey)
+				if err != nil {
+					return err
+				}
+
+			}
+
+			// if we don't have the trieKey we can derive it from the log tenant, but
+			// we don't know if its log version 0 or log version 1, so do both.
+			if logID == "" {
+
+				logIDVersion0 := []byte(logTenant)
+
+				trieKeyVersion0 := massifs.NewTrieKey(
+					massifs.KeyType(domain),
+					logIDVersion0,
+					[]byte(appID),
+				)
+
+				logTenantUUIDStr := strings.TrimPrefix("tenant/", logTenant)
+				logTenantUUID, err := uuid.Parse(logTenantUUIDStr)
+				if err != nil {
+
+					// we could continue with just version 0 here
+					// but if we error here we know the log tenant isn't a valid
+					// tenant identity, so there is no point searching for the trie key
+					// as we know its invalid.
+					return err
+				}
+
+				logIDVersion1, err := logTenantUUID.MarshalBinary()
+				if err != nil {
+					return err
+				}
+
+				trieKeyVersion1 := massifs.NewTrieKey(
+					massifs.KeyType(domain),
+					logIDVersion1,
+					[]byte(appID),
+				)
+
+				trieIndexMatches, err = findTrieKeys(cmd.massifReader, logTenant, trieKeyVersion0, trieKeyVersion1)
+				if err != nil {
+					return err
+				}
+
+			}
+
+			// if we want the trie index matches log them and return
+			if !asMMRIndexes {
+				log("matches: %v", trieIndexMatches)
+				return nil
+			}
+
+			// otherwise we want to log the mmr index matches
+			mmrIndexMatches := []uint64{}
+			for _, trieIndex := range trieIndexMatches {
+
+				mmrIndex := mmr.MMRIndex(trieIndex)
+				mmrIndexMatches = append(mmrIndexMatches, mmrIndex)
+			}
+
+			log("matches: %v", mmrIndexMatches)
+
+			return nil
+
+		},
+	}
+}

--- a/findtrieentries.go
+++ b/findtrieentries.go
@@ -186,12 +186,12 @@ func NewFindTrieEntriesCmd() *cli.Command {
 			},
 			&cli.Int64Flag{
 				Name:  massifRangeStartFlagName,
-				Usage: fmt.Sprintf("if set, start the search for matching trie entries at the massif at this given massif index, Requires %v to be set as well. if omitted will search all massifs.", massifRangeEndFlagName),
+				Usage: fmt.Sprintf("if set, start the search for matching trie entries at the massif at this given massif index, also requires %v to be set. if omitted will search all massifs.", massifRangeEndFlagName),
 				Value: -1,
 			},
 			&cli.Int64Flag{
 				Name:  massifRangeEndFlagName,
-				Usage: fmt.Sprintf("if set, end the search for matching trie entries at the massif at this given massif index, Requires %v to be set as well. if omitted will search all massifs.", massifRangeStartFlagName),
+				Usage: fmt.Sprintf("if set, end the search for matching trie entries at the massif at this given massif index, also requires %v to be set. if omitted will search all massifs.", massifRangeStartFlagName),
 				Value: -1,
 			},
 		},


### PR DESCRIPTION
## Overview
* add IKWID (I know what i'm doing) command to veracity to find trie entries based on given trie keys

## Testing

help text:

```
NAME:
   veracity find-trie-entries - finds the matching trie entries for the given trie key.

                                    By default returns all mmr Indexes of matching trie entries.

                                    The trieKey is HASH(DOMAIN | LOGID | APPID)

                                    NOTE: ignores the global --tenant option, please use --log-tenant command option.


USAGE:
   veracity find-trie-entries [command options] [arguments...]

OPTIONS:
   --log-tenant value    the tenant of the log to search in. Required or can be derived from log-id.
   --log-id value        the hexadecimal representation of the log ID. Required or can be derived from log-tenant.
   --app-id value        the app ID. For eventsv1 or assetsv2 this is the event id.
   --domain value        the domain used to derive the trie key. (default: 0)
   --as-leafindexes      if true, returns a list of matching leaf indexes instead of mmr indexes. (default: false)
   --massif-start value  if set, start the search for matching trie entries at the massif at this given massif index. if omitted will start search at massif 0. (default: 0)
   --massif-end value    if set, end the search for matching trie entries at the massif at this given massif index. if omitted will end search at the last massif. (default: -1)
   --help, -h            show help
```


manually tested with an eventsv1 event and an assetsv2 event:

eventsv1 event:
```
./veracity --loglevel DEBUG --data-url https://app.dev-jgough-0.dev.datatrails.ai/verifiabledata find-trie-entries --log-tenant tenant/7e4a511f-d4ae-425c-b915-9c4ac09ca929 --app-id events/01948dd3-4346-7b59-9825-fabb55989b39
trieKey version 0: ca80d222d44ffa7de854373235c907dad892ff120abd60ce30e433443693a8d2
trieKey version 1: 41311e0881e7c0f40fc91eb71015ae113d2fc09660353788f22d546c85ded333
checking 8192 trie entries in massif 0 for matches
checking 8192 trie entries in massif 1 for matches
checking 8192 trie entries in massif 2 for matches
checking 8192 trie entries in massif 3 for matches
checking 8192 trie entries in massif 4 for matches
checking 8192 trie entries in massif 5 for matches
checking 8192 trie entries in massif 6 for matches
checking 8192 trie entries in massif 7 for matches
checking 3038 trie entries in massif 8 for matches
entries considered: 68574
matches: [137135]

```

as leaf indexes:

```
./veracity --loglevel DEBUG --data-url https://app.dev-jgough-0.dev.datatrails.ai/verifiabledata find-trie-entries --log-tenant tenant/7e4a511f-d4ae-425c-b915-9c4ac09ca929 --app-id events/01948dd3-4346-7b59-9825-fabb55989b39 --as-leafindexes
trieKey version 0: ca80d222d44ffa7de854373235c907dad892ff120abd60ce30e433443693a8d2
trieKey version 1: 41311e0881e7c0f40fc91eb71015ae113d2fc09660353788f22d546c85ded333
checking 8192 trie entries in massif 0 for matches
checking 8192 trie entries in massif 1 for matches
checking 8192 trie entries in massif 2 for matches
checking 8192 trie entries in massif 3 for matches
checking 8192 trie entries in massif 4 for matches
checking 8192 trie entries in massif 5 for matches
checking 8192 trie entries in massif 6 for matches
checking 8192 trie entries in massif 7 for matches
checking 3038 trie entries in massif 8 for matches
entries considered: 68574
matches: [68572]
```

assetsv2 event considering all massifs:

```
./veracity --loglevel DEBUG --data-url https://app.dev-jgough-0.dev.datatrails.ai/verifiabledata find-trie-entries --log-tenant tenant/7e4a511f-d4ae-425c-b915-9c4ac09ca929 --app-id assets/ea596dcc-8f38-4af6-8c3f-8c8dd69da6d0/events/60ee85f8-6f10-4f6e-9dd8-fa54294acd7d
trieKey version 0: fad5a0dcfad9083c86bfd49dab6eb49ae511453939d6be2c36dee9a633705ac6
trieKey version 1: 1fe4fcd29b1783fa438dcb5933ef33b9016fef9d59eb9c435789c3e1132cb3b4
checking 8192 trie entries in massif 0 for matches
checking 8192 trie entries in massif 1 for matches
checking 8192 trie entries in massif 2 for matches
checking 8192 trie entries in massif 3 for matches
checking 8192 trie entries in massif 4 for matches
checking 8192 trie entries in massif 5 for matches
checking 8192 trie entries in massif 6 for matches
checking 8192 trie entries in massif 7 for matches
checking 3038 trie entries in massif 8 for matches
entries considered: 68574
matches: [137136]

```

assetsv2 event with massif range:

```
./veracity --loglevel DEBUG --data-url https://app.dev-jgough-0.dev.datatrails.ai/verifiabledata find-trie-entries --log-tenant tenant/7e4a511f-d4ae-425c-b915-9c4ac09ca929 --app-id assets/ea596dcc-8f38-4af6-8c3f-8c8dd69da6d0/events/60ee85f8-6f10-4f6e-9dd8-fa54294acd7d --massif-start 7 --massif-end 8
trieKey version 0: fad5a0dcfad9083c86bfd49dab6eb49ae511453939d6be2c36dee9a633705ac6
trieKey version 1: 1fe4fcd29b1783fa438dcb5933ef33b9016fef9d59eb9c435789c3e1132cb3b4
checking 8192 trie entries in massif 7 for matches
checking 3038 trie entries in massif 8 for matches
entries considered: 11230
matches: [137136]
```

assetsv2 event with massif range of 1 massif:

```
./veracity --loglevel DEBUG --data-url https://app.dev-jgough-0.dev.datatrails.ai/verifiabledata find-trie-entries --log-tenant tenant/7e4a511f-d4ae-425c-b915-9c4ac09ca929 --app-id assets/ea596dcc-8f38-4af6-8c3f-8c8dd69da6d0/events/60ee85f8-6f10-4f6e-9dd8-fa54294acd7d --massif-start 8 --massif-end 8
trieKey version 0: fad5a0dcfad9083c86bfd49dab6eb49ae511453939d6be2c36dee9a633705ac6
trieKey version 1: 1fe4fcd29b1783fa438dcb5933ef33b9016fef9d59eb9c435789c3e1132cb3b4
checking 3038 trie entries in massif 8 for matches
entries considered: 3038
matches: [137136]
```

assetsv2 event with massif range outside of the massif the event is in:

```
./veracity --loglevel DEBUG --data-url https://app.dev-jgough-0.dev.datatrails.ai/verifiabledata find-trie-entries --log-tenant tenant/7e4a511f-d4ae-425c-b915-9c4ac09ca929 --app-id assets/ea596dcc-8f38-4af6-8c3f-8c8dd69da6d0/events/60ee85f8-6f10-4f6e-9dd8-fa54294acd7d --massif-start 3 --massif-end 5
trieKey version 0: fad5a0dcfad9083c86bfd49dab6eb49ae511453939d6be2c36dee9a633705ac6
trieKey version 1: 1fe4fcd29b1783fa438dcb5933ef33b9016fef9d59eb9c435789c3e1132cb3b4
checking 8192 trie entries in massif 3 for matches
checking 8192 trie entries in massif 4 for matches
checking 8192 trie entries in massif 5 for matches
entries considered: 24576
matches: []
```


