### PR TITLE
fix log tenant default for verify included re: AB#10216

### DIFF
--- a/verifyincluded.go
+++ b/verifyincluded.go
@@ -113,6 +113,10 @@ Note: for publicly attested events, or shared protected events, you must use --t
 			// verifyEvent defaults it to tenantIdentity for the benefit of the remote reader implementation
 			tenantLogPath := cCtx.String("data-local")
 
+			if tenantLogPath == "" {
+				tenantLogPath = tenantIdentity
+			}
+
 			appData, err := veracityapp.ReadAppData(cCtx.Args().Len() == 0, cCtx.Args().Get(0))
 			if err != nil {
 				return err
@@ -143,12 +147,12 @@ Note: for publicly attested events, or shared protected events, you must use --t
 				// find the log tenant path if not provided
 				if tenantLogPath == "" {
 
-					logTenant, err := event.LogTenant()
+					var err error
+					tenantLogPath, err = event.LogTenant()
 					if err != nil {
 						return err
 					}
 
-					tenantLogPath = logTenant
 				}
 
 				// check if we need this event is part of a different massif than the previous event

--- a/verifyincluded.go
+++ b/verifyincluded.go
@@ -113,10 +113,6 @@ Note: for publicly attested events, or shared protected events, you must use --t
 			// verifyEvent defaults it to tenantIdentity for the benefit of the remote reader implementation
 			tenantLogPath := cCtx.String("data-local")
 
-			if tenantLogPath == "" {
-				tenantLogPath = tenantIdentity
-			}
-
 			appData, err := veracityapp.ReadAppData(cCtx.Args().Len() == 0, cCtx.Args().Get(0))
 			if err != nil {
 				return err
@@ -143,6 +139,17 @@ Note: for publicly attested events, or shared protected events, you must use --t
 
 				// get the massif index for the event event
 				massifIndex := massifs.MassifIndexFromMMRIndex(cmd.massifHeight, event.MMRIndex())
+
+				// find the log tenant path if not provided
+				if tenantLogPath == "" {
+
+					logTenant, err := event.LogTenant()
+					if err != nil {
+						return err
+					}
+
+					tenantLogPath = logTenant
+				}
 
 				// check if we need this event is part of a different massif than the previous event
 				//


### PR DESCRIPTION
## Overview
* fix default tenant code for verify inclusion

## Testing

manually tested:

```
cat ev1.json | ./veracity --data-url https://app.dev-wp-0.dev.datatrails.ai/verifiabledata --loglevel=INFO verify-included
verifying protected events for the event creator
OK|18 10|[d56b6b51225b02f84ebea9a94c1d15211304ec476cfdadbce046dc492bcdc2b8, 9d65b7f8a056390d7fe923f8325d1e87e0aa96b8471e9c904327d6312ccb1ca0]
```

## TODO 

* add systemtest around default tenant option