### PR TITLE
Promote find mmr entries and find trie entries to non IKWID commands

### DIFF
--- a/app.go
+++ b/app.go
@@ -58,14 +58,15 @@ func AddCommands(app *cli.App, ikwid bool) *cli.App {
 	app.Commands = append(app.Commands, NewReplicateLogsCmd())
 	app.Commands = append(app.Commands, NewReceiptCmd())
 
+	app.Commands = append(app.Commands, NewFindTrieEntriesCmd())
+	app.Commands = append(app.Commands, NewFindMMREntriesCmd())
+
 	if ikwid {
 		app.Commands = append(app.Commands, NewMassifsCmd())
 		app.Commands = append(app.Commands, NewLogTailCmd())
 		app.Commands = append(app.Commands, NewEventDiagCmd())
 		app.Commands = append(app.Commands, NewDiagCmd())
 		app.Commands = append(app.Commands, NewNodeScanCmd())
-		app.Commands = append(app.Commands, NewFindTrieEntriesCmd())
-		app.Commands = append(app.Commands, NewFindMMREntriesCmd())
 	}
 	return app
 }

--- a/findmmrentries.go
+++ b/findmmrentries.go
@@ -79,7 +79,7 @@ func findMMREntries(
 		// NOTE: the leaf index and trie index are equivilent.
 		mmrLeafEntries := massifContext.MassifLeafCount()
 
-		log.Debugf("checking %v trie entries in massif %v for matches", mmrLeafEntries, massifIndex)
+		log.Debugf("checking %v mmr entries in massif %v for matches", mmrLeafEntries, massifIndex)
 
 		// check each mmr leaf entry for matching mmr entry
 		for range mmrLeafEntries {
@@ -196,12 +196,12 @@ func NewFindMMREntriesCmd() *cli.Command {
 			},
 			&cli.Int64Flag{
 				Name:  massifRangeStartFlagName,
-				Usage: "if set, start the search for matching trie entries at the massif at this given massif index. if omitted will start search at massif 0.",
+				Usage: "if set, start the search for matching mmr entries at the massif at this given massif index. if omitted will start search at massif 0.",
 				Value: 0,
 			},
 			&cli.Int64Flag{
 				Name:  massifRangeEndFlagName,
-				Usage: "if set, end the search for matching trie entries at the massif at this given massif index. if omitted will end search at the last massif.",
+				Usage: "if set, end the search for matching mmr entries at the massif at this given massif index. if omitted will end search at the last massif.",
 				Value: -1,
 			},
 		},

--- a/tests/findmmrentries/findmmrentries_test.go
+++ b/tests/findmmrentries/findmmrentries_test.go
@@ -1,0 +1,226 @@
+package findmmrentries
+
+import (
+	"io"
+	"os"
+	"strings"
+
+	"github.com/datatrails/veracity"
+	"github.com/datatrails/veracity/tests/katdata"
+)
+
+const (
+	prodPublicTenant   = "tenant/6ea5cd00-c711-3649-6914-7b125928bbb4"
+	prodEventsv1Tenant = "tenant/97e90a09-8c56-40df-a4de-42fde462ef6f"
+)
+
+// TestAssetsV2EventStdIn tests we can find
+// the correct PROD public assetsv2 event mmr entry match
+func (s *FindMMREntriesSuite) TestAssetsV2EventStdIn() {
+	assert := s.Assert()
+	require := s.Require()
+
+	app := veracity.NewApp("version", true)
+	veracity.AddCommands(app, true)
+
+	// note: the suite does a before & after pipe for Stdin
+	s.StdinWriteAndClose(katdata.KnownGoodPublicAssetsV1EventLaterMassif)
+
+	// redirect std out to a known pipe so we can capture it
+	rescueStdout := os.Stdout
+	defer func() { os.Stdout = rescueStdout }() // ensure we redirect std out back after
+
+	reader, writer, _ := os.Pipe()
+	os.Stdout = writer
+
+	err := app.Run([]string{
+		"veracity",
+		"find-mmr-entries",
+		"--log-tenant", prodPublicTenant,
+	})
+	assert.NoErrorf(err, "the event is a known good event from the public production tenant, yet we have errored trying to find the mmr entries")
+
+	writer.Close()
+	actualBytes, err := io.ReadAll(reader)
+	require.NoError(err)
+
+	// convert the stdout to a string and strip the newlines
+	actual := strings.ReplaceAll(string(actualBytes), "\n", "")
+
+	assert.Equal("matches: [27899]", actual)
+}
+
+// TestAssetsV2EventAsLeafIndexStdIn tests we can find
+// the correct PROD public assetsv2 event mmr entry match as
+// a leaf index.
+func (s *FindMMREntriesSuite) TestAssetsV2EventAsLeafIndexStdIn() {
+	assert := s.Assert()
+	require := s.Require()
+
+	app := veracity.NewApp("version", true)
+	veracity.AddCommands(app, true)
+
+	// note: the suite does a before & after pipe for Stdin
+	s.StdinWriteAndClose(katdata.KnownGoodPublicAssetsV1EventLaterMassif)
+
+	// redirect std out to a known pipe so we can capture it
+	rescueStdout := os.Stdout
+	defer func() { os.Stdout = rescueStdout }() // ensure we redirect std out back after
+
+	reader, writer, _ := os.Pipe()
+	os.Stdout = writer
+
+	err := app.Run([]string{
+		"veracity",
+		"find-mmr-entries",
+		"--log-tenant", prodPublicTenant,
+		"--massif-start", "1",
+		"--massif-end", "1", // the event is in massif 1
+		"--as-leafindexes", "true",
+	})
+	assert.NoErrorf(err, "the event is a known good event from the public production tenant, yet we have errored trying to find the mmr entries")
+
+	writer.Close()
+	actualBytes, err := io.ReadAll(reader)
+	require.NoError(err)
+
+	// convert the stdout to a string and strip the newlines
+	actual := strings.ReplaceAll(string(actualBytes), "\n", "")
+
+	assert.Equal("matches: [13952]", actual)
+}
+
+// TestAssetsV2EventWrongMassifStdIn tests we CANNOT find
+// the correct PROD public assetsv2 event mmr entry match
+// if we set the range of massifs to not include the massif the event is in.
+func (s *FindMMREntriesSuite) TestAssetsV2EventWrongMassifStdIn() {
+	assert := s.Assert()
+	require := s.Require()
+
+	app := veracity.NewApp("version", true)
+	veracity.AddCommands(app, true)
+
+	// note: the suite does a before & after pipe for Stdin
+	s.StdinWriteAndClose(katdata.KnownGoodPublicAssetsV1EventLaterMassif)
+
+	// redirect std out to a known pipe so we can capture it
+	rescueStdout := os.Stdout
+	defer func() { os.Stdout = rescueStdout }() // ensure we redirect std out back after
+
+	reader, writer, _ := os.Pipe()
+	os.Stdout = writer
+
+	err := app.Run([]string{
+		"veracity",
+		"find-mmr-entries",
+		"--log-tenant", prodPublicTenant,
+		"--massif-start", "0",
+		"--massif-end", "0", // the actual event is in massif 1
+	})
+	assert.NoErrorf(err, "the event is a known good event from the public production tenant, yet we have errored trying to find the mmr entries")
+
+	writer.Close()
+	actualBytes, err := io.ReadAll(reader)
+	require.NoError(err)
+
+	// convert the stdout to a string and strip the newlines
+	actual := strings.ReplaceAll(string(actualBytes), "\n", "")
+
+	assert.Equal("matches: []", actual)
+}
+
+// TestAssetsV2EventCorrectMassifStdIn tests we CAN find
+// the correct PROD public assetsv2 event mmr entry match
+// if we set the range of massifs to include ONLY the massif the event is in.
+func (s *FindMMREntriesSuite) TestAssetsV2EventCorrectMassifStdIn() {
+	assert := s.Assert()
+	require := s.Require()
+
+	app := veracity.NewApp("version", true)
+	veracity.AddCommands(app, true)
+
+	// note: the suite does a before & after pipe for Stdin
+	s.StdinWriteAndClose(katdata.KnownGoodPublicAssetsV1EventLaterMassif)
+
+	// redirect std out to a known pipe so we can capture it
+	rescueStdout := os.Stdout
+	defer func() { os.Stdout = rescueStdout }() // ensure we redirect std out back after
+
+	rescueStderr := os.Stderr
+	defer func() { os.Stderr = rescueStderr }() // ensure we redirect std err back after
+
+	readerStdOut, writerStdOut, _ := os.Pipe()
+	os.Stdout = writerStdOut
+
+	readerStdErr, writerStdErr, _ := os.Pipe()
+	os.Stderr = writerStdErr
+
+	err := app.Run([]string{
+		"veracity",
+		"--loglevel", "DEBUG",
+		"find-mmr-entries",
+		"--log-tenant", prodPublicTenant,
+		"--massif-start", "1",
+		"--massif-end", "1", // the actual event is in massif 1
+	})
+	assert.NoErrorf(err, "the event is a known good event from the public production tenant, yet we have errored trying to find the mmr entries")
+
+	writerStdOut.Close()
+	actualStdOutBytes, err := io.ReadAll(readerStdOut)
+	require.NoError(err)
+
+	writerStdErr.Close()
+	actualStdErrBytes, err := io.ReadAll(readerStdErr)
+	require.NoError(err)
+
+	// convert the stdout to string and string new lines and convert stderr to string
+	actualStdOut := strings.ReplaceAll(string(actualStdOutBytes), "\n", "")
+	actualStdErr := string(actualStdErrBytes)
+
+	// assert we are checking the correct massif
+	assert.Contains(actualStdErr, "mmr entries in massif 1 for matches")
+
+	// assert we are not checking the neighbouring massifs
+	assert.NotContains(actualStdErr, "mmr entries in massif 0 for matches")
+	assert.NotContains(actualStdErr, "mmr entries in massif 2 for matches")
+
+	assert.Equal("matches: [27899]", actualStdOut)
+}
+
+// TestEventsV1EventRepeatedAppDataStdIn tests we can find
+// the correct PROD eventsv1 event mmr entry matches for app data used
+// for 2 events on the same log tenant.
+func (s *FindMMREntriesSuite) TestEventsV1EventRepeatedAppDataStdIn() {
+	assert := s.Assert()
+	require := s.Require()
+
+	app := veracity.NewApp("version", true)
+	veracity.AddCommands(app, true)
+
+	// note: the suite does a before & after pipe for Stdin
+	s.StdinWriteAndClose(katdata.KnownGoodEventsv1RepeatedAppData)
+
+	// redirect std out to a known pipe so we can capture it
+	rescueStdout := os.Stdout
+	defer func() { os.Stdout = rescueStdout }() // ensure we redirect std out back after
+
+	reader, writer, _ := os.Pipe()
+	os.Stdout = writer
+
+	err := app.Run([]string{
+		"veracity",
+		"find-mmr-entries",
+		"--log-tenant", prodEventsv1Tenant,
+	})
+	assert.NoErrorf(err, "the event is a known good event from the production tenant we are using for test eventsv1 events, yet we have errored trying to find the mmr entries")
+
+	writer.Close()
+	actualBytes, err := io.ReadAll(reader)
+	require.NoError(err)
+
+	// convert the stdout to a string and strip the newlines
+	actual := strings.ReplaceAll(string(actualBytes), "\n", "")
+
+	// check we get back matches mmr indexes 26 and 31
+	assert.Equal("matches: [26 31]", actual)
+}

--- a/tests/findmmrentries/suite_test.go
+++ b/tests/findmmrentries/suite_test.go
@@ -1,0 +1,18 @@
+package findmmrentries
+
+import (
+	"testing"
+
+	"github.com/datatrails/veracity/tests"
+	"github.com/stretchr/testify/suite"
+)
+
+// FindMMREntriesSuite deals with tests around finding mmr entries
+type FindMMREntriesSuite struct {
+	tests.IntegrationTestSuite
+}
+
+func TestFindMMREntriesSuite(t *testing.T) {
+
+	suite.Run(t, new(FindMMREntriesSuite))
+}

--- a/tests/findtrieentries/findtrieentries_test.go
+++ b/tests/findtrieentries/findtrieentries_test.go
@@ -1,0 +1,213 @@
+package findtrieentries
+
+import (
+	"io"
+	"os"
+	"strings"
+
+	"github.com/datatrails/veracity"
+)
+
+const (
+	prodPublicTenant   = "tenant/6ea5cd00-c711-3649-6914-7b125928bbb4"
+	prodEventsv1Tenant = "tenant/97e90a09-8c56-40df-a4de-42fde462ef6f"
+)
+
+// TestAssetsV2EventStdIn tests we can find
+// the correct PROD public assetsv2 event trie entry match
+func (s *FindTrieEntriesSuite) TestAssetsV2EventStdIn() {
+	assert := s.Assert()
+	require := s.Require()
+
+	app := veracity.NewApp("version", true)
+	veracity.AddCommands(app, true)
+
+	// redirect std out to a known pipe so we can capture it
+	rescueStdout := os.Stdout
+	defer func() { os.Stdout = rescueStdout }() // ensure we redirect std out back after
+
+	reader, writer, _ := os.Pipe()
+	os.Stdout = writer
+
+	err := app.Run([]string{
+		"veracity",
+		"find-trie-entries",
+		"--log-tenant", prodPublicTenant,
+		"--app-id", "assets/20e0864f-423c-4a09-8819-baac2ed326e4/events/effa4ea1-e96d-4272-8c06-c09453c75621", // identity of the event with the public prefix striped
+	})
+	assert.NoErrorf(err, "the event is a known good event from the public production tenant, yet we have errored trying to find the trie entries")
+
+	writer.Close()
+	actualBytes, err := io.ReadAll(reader)
+	require.NoError(err)
+
+	// convert the stdout to a string and strip the newlines
+	actual := strings.ReplaceAll(string(actualBytes), "\n", "")
+
+	assert.Equal("matches: [27899]", actual)
+}
+
+// TestAssetsV2EventAsLeafIndexStdIn tests we can find
+// the correct PROD public assetsv2 event trie entry match as
+// a leaf index.
+func (s *FindTrieEntriesSuite) TestAssetsV2EventAsLeafIndexStdIn() {
+	assert := s.Assert()
+	require := s.Require()
+
+	app := veracity.NewApp("version", true)
+	veracity.AddCommands(app, true)
+
+	// redirect std out to a known pipe so we can capture it
+	rescueStdout := os.Stdout
+	defer func() { os.Stdout = rescueStdout }() // ensure we redirect std out back after
+
+	reader, writer, _ := os.Pipe()
+	os.Stdout = writer
+
+	err := app.Run([]string{
+		"veracity",
+		"find-trie-entries",
+		"--log-tenant", prodPublicTenant,
+		"--app-id", "assets/20e0864f-423c-4a09-8819-baac2ed326e4/events/effa4ea1-e96d-4272-8c06-c09453c75621", // identity of the event with the public prefix striped
+		"--massif-start", "1",
+		"--massif-end", "1", // event is in massif 1
+		"--as-leafindexes",
+	})
+	assert.NoErrorf(err, "the event is a known good event from the public production tenant, yet we have errored trying to find the trie entries")
+
+	writer.Close()
+	actualBytes, err := io.ReadAll(reader)
+	require.NoError(err)
+
+	// convert the stdout to a string and strip the newlines
+	actual := strings.ReplaceAll(string(actualBytes), "\n", "")
+
+	assert.Equal("matches: [13952]", actual)
+}
+
+// TestAssetsV2EventWrongMassifStdIn tests we CANNOT find
+// the correct PROD public assetsv2 event trie entry match
+// if we set the range of massifs to not include the massif the event is in.
+func (s *FindTrieEntriesSuite) TestAssetsV2EventWrongMassifStdIn() {
+	assert := s.Assert()
+	require := s.Require()
+
+	app := veracity.NewApp("version", true)
+	veracity.AddCommands(app, true)
+
+	// redirect std out to a known pipe so we can capture it
+	rescueStdout := os.Stdout
+	defer func() { os.Stdout = rescueStdout }() // ensure we redirect std out back after
+
+	reader, writer, _ := os.Pipe()
+	os.Stdout = writer
+
+	err := app.Run([]string{
+		"veracity",
+		"find-trie-entries",
+		"--log-tenant", prodPublicTenant,
+		"--app-id", "assets/20e0864f-423c-4a09-8819-baac2ed326e4/events/effa4ea1-e96d-4272-8c06-c09453c75621", // identity of the event with the public prefix striped
+		"--massif-start", "0",
+		"--massif-end", "0", // event is in massif 1
+	})
+	assert.NoErrorf(err, "the event is a known good event from the public production tenant, yet we have errored trying to find the trie entries")
+
+	writer.Close()
+	actualBytes, err := io.ReadAll(reader)
+	require.NoError(err)
+
+	// convert the stdout to a string and strip the newlines
+	actual := strings.ReplaceAll(string(actualBytes), "\n", "")
+
+	assert.Equal("matches: []", actual)
+}
+
+// TestAssetsV2EventCorrectMassifStdIn tests we CAN find
+// the correct PROD public assetsv2 event trie entry match
+// if we set the range of massifs to include ONLY the massif the event is in.
+func (s *FindTrieEntriesSuite) TestAssetsV2EventCorrectMassifStdIn() {
+	assert := s.Assert()
+	require := s.Require()
+
+	app := veracity.NewApp("version", true)
+	veracity.AddCommands(app, true)
+
+	// redirect std out to a known pipe so we can capture it
+	rescueStdout := os.Stdout
+	defer func() { os.Stdout = rescueStdout }() // ensure we redirect std out back after
+
+	rescueStderr := os.Stderr
+	defer func() { os.Stderr = rescueStderr }() // ensure we redirect std err back after
+
+	readerStdOut, writerStdOut, _ := os.Pipe()
+	os.Stdout = writerStdOut
+
+	readerStdErr, writerStdErr, _ := os.Pipe()
+	os.Stderr = writerStdErr
+
+	err := app.Run([]string{
+		"veracity",
+		"--loglevel", "DEBUG",
+		"find-trie-entries",
+		"--log-tenant", prodPublicTenant,
+		"--app-id", "assets/20e0864f-423c-4a09-8819-baac2ed326e4/events/effa4ea1-e96d-4272-8c06-c09453c75621", // identity of the event with the public prefix striped
+		"--massif-start", "1",
+		"--massif-end", "1", // event is in massif 1
+	})
+	assert.NoErrorf(err, "the event is a known good event from the public production tenant, yet we have errored trying to find the trie entries")
+
+	writerStdOut.Close()
+	actualStdOutBytes, err := io.ReadAll(readerStdOut)
+	require.NoError(err)
+
+	writerStdErr.Close()
+	actualStdErrBytes, err := io.ReadAll(readerStdErr)
+	require.NoError(err)
+
+	// convert the stdout to string and string new lines and convert stderr to string
+	actualStdOut := strings.ReplaceAll(string(actualStdOutBytes), "\n", "")
+	actualStdErr := string(actualStdErrBytes)
+
+	// assert we are checking the correct massif
+	assert.Contains(actualStdErr, "trie entries in massif 1 for matches")
+
+	// assert we are not checking the neighbouring massifs
+	assert.NotContains(actualStdErr, "trie entries in massif 0 for matches")
+	assert.NotContains(actualStdErr, "trie entries in massif 2 for matches")
+
+	assert.Equal("matches: [27899]", actualStdOut)
+}
+
+// TestEventsV1EventStdIn tests we can find
+// the correct PROD eventsv1 event trie entry match.
+func (s *FindTrieEntriesSuite) TestEventsV1EventStdIn() {
+	assert := s.Assert()
+	require := s.Require()
+
+	app := veracity.NewApp("version", true)
+	veracity.AddCommands(app, true)
+
+	// redirect std out to a known pipe so we can capture it
+	rescueStdout := os.Stdout
+	defer func() { os.Stdout = rescueStdout }() // ensure we redirect std out back after
+
+	reader, writer, _ := os.Pipe()
+	os.Stdout = writer
+
+	err := app.Run([]string{
+		"veracity",
+		"find-trie-entries",
+		"--log-tenant", prodEventsv1Tenant,
+		"--app-id", "events/0194b168-bac0-75e6-bbc4-a47cc45bdbf5", // identity of the event
+	})
+	assert.NoErrorf(err, "the event is a known good event from the production tenant we are using for test eventsv1 events, yet we have errored trying to find the trie entries")
+
+	writer.Close()
+	actualBytes, err := io.ReadAll(reader)
+	require.NoError(err)
+
+	// convert the stdout to a string and strip the newlines
+	actual := strings.ReplaceAll(string(actualBytes), "\n", "")
+
+	assert.Equal("matches: [4]", actual)
+}

--- a/tests/findtrieentries/suite_test.go
+++ b/tests/findtrieentries/suite_test.go
@@ -1,0 +1,18 @@
+package findtrieentries
+
+import (
+	"testing"
+
+	"github.com/datatrails/veracity/tests"
+	"github.com/stretchr/testify/suite"
+)
+
+// FindTrieEntriesSuite deals with tests around finding trie entries
+type FindTrieEntriesSuite struct {
+	tests.IntegrationTestSuite
+}
+
+func TestFindTrieEntriesSuite(t *testing.T) {
+
+	suite.Run(t, new(FindTrieEntriesSuite))
+}

--- a/tests/katdata/eventsingles.go
+++ b/tests/katdata/eventsingles.go
@@ -69,6 +69,56 @@ var (
   }
 }`)
 
+	KnownGoodPublicAssetsV1EventLaterMassif = []byte(`{
+    "identity": "publicassets/20e0864f-423c-4a09-8819-baac2ed326e4/events/effa4ea1-e96d-4272-8c06-c09453c75621",
+    "asset_identity": "publicassets/20e0864f-423c-4a09-8819-baac2ed326e4",
+    "event_attributes": {
+        "5": "put in the over until golden brown",
+        "1": "pour flour and milk into bowl",
+        "2": "mix together until gloopy",
+        "3": "slowly add in the sugar while still mixing",
+        "4": "finally add in the eggs"
+    },
+    "asset_attributes": {},
+    "operation": "Record",
+    "behaviour": "RecordEvidence",
+    "timestamp_declared": "2025-02-05T09:21:55Z",
+    "timestamp_accepted": "2025-02-05T09:21:55Z",
+    "timestamp_committed": "2025-02-05T09:21:55.785410491Z",
+    "principal_declared": {
+        "issuer": "",
+        "subject": "",
+        "display_name": "",
+        "email": ""
+    },
+    "principal_accepted": {
+        "issuer": "",
+        "subject": "",
+        "display_name": "",
+        "email": ""
+    },
+    "confirmation_status": "CONFIRMED",
+    "transaction_id": "",
+    "block_number": 0,
+    "transaction_index": 0,
+    "from": "0x23F97B5b34433f4fF55898fFF4b0682Deb25Cafe",
+    "tenant_identity": "tenant/97e90a09-8c56-40df-a4de-42fde462ef6f",
+    "merklelog_entry": {
+        "commit": {
+            "index": "27899",
+            "idtimestamp": "0194d56a8a4e058c00"
+        },
+        "confirm": {
+            "mmr_size": "27900",
+            "root": "eyQHuUeNhSupHV7HCGqcIBK/tgcuw/X8XfrdlGvGNdOq1bKe35hi3Sja6vBYaXy10p3vvTGkyMtu4Wr8zeZ6BNWWPqeNUUt3vZVAH784nsntSjgKVC2JiiiQJZustlQ0HMa1QJqA6AjzKnVkn5P9u9ZPUPdU7Yl6sA2Ts9LyXLyqTBzs+mD7xCycyFiPdcsM4b1K8Xzply9KNS1MT4KILGOeOOI5mu4BWjR8G9CRro7KYJbQkHWCLCwk4CPWGxgF",
+            "timestamp": "1738747318412",
+            "idtimestamp": "",
+            "signed_tree_head": ""
+        },
+        "unequivocal": null
+    }
+}`)
+
 	KnownGoodEventsV1Event = []byte(`{
     "identity": "events/0194b168-bac0-75e6-bbc4-a47cc45bdbf5",
     "attributes": {
@@ -89,6 +139,22 @@ var (
         "index": "4",
         "idtimestamp": "0194b168bcde03be00"
     }
+}`)
+
+	// KnownGoodEventsv1RepeatedAppData is a known good events v1 app data (attributes + trails)
+	// on prod, that was used to create exactly 2 events within the same log tenant.
+	KnownGoodEventsv1RepeatedAppData = []byte(`{
+  "attributes": {
+      "4": "finally add in the eggs",
+      "5": "put in the oven until golden brown",
+      "6": "leave to cool",
+      "1": "pour flour and milk into bowl",
+      "2": "mix together until gloopy",
+      "3": "slowly add in the sugar while still mixing"
+  },
+  "trails": [
+      "cake"
+  ]
 }`)
 
 	// The 'tamper' is the 'a' from a single arc_ event attribute has been clipped.


### PR DESCRIPTION
## Overview
* Promote find mmr entries and find trie entries to non IKWID commands

## Testing
* Add prod based verification tests to ensure they work, these include ensure the massif filter works for both commands.

RE: AB#10376