### PR TITLE
Dev/jgough/10376 support local data

### DIFF
--- a/findmmrentries.go
+++ b/findmmrentries.go
@@ -244,8 +244,11 @@ func NewFindMMREntriesCmd() *cli.Command {
 			}
 
 			// configure the cmd massif reader
-			cCtx.Set("tenant", logTenant)
-			if err := cfgMassifReader(cmd, cCtx); err != nil {
+			if err = cCtx.Set("tenant", logTenant); err != nil {
+				return err
+			}
+
+			if err = cfgMassifReader(cmd, cCtx); err != nil {
 				return err
 			}
 

--- a/findmmrentries.go
+++ b/findmmrentries.go
@@ -29,7 +29,7 @@ const (
 func findMMREntries(
 	log logger.Logger,
 	massifReader MassifReader,
-	logTenant string,
+	tenantLogPath string,
 	massifStartIndex int64,
 	massifEndIndex int64,
 	massifHeight uint8,
@@ -54,10 +54,15 @@ func findMMREntries(
 			break
 		}
 
-		massifContext, err := massifReader.GetMassif(context.Background(), logTenant, uint64(massifIndex))
+		massifContext, err := massifReader.GetMassif(context.Background(), tenantLogPath, uint64(massifIndex))
 
 		// check if we have reached the last massif for the log tenant
 		if errors.Is(err, massifs.ErrMassifNotFound) {
+			break
+		}
+
+		// check if we have reached the last massif for local log
+		if errors.Is(err, massifs.ErrLogFileMassifNotFound) {
 			break
 		}
 
@@ -228,8 +233,19 @@ func NewFindMMREntriesCmd() *cli.Command {
 			massifStartIndex := cCtx.Int64(massifRangeStartFlagName)
 			massifEndIndex := cCtx.Int64(massifRangeEndFlagName)
 
+			// If we are reading the massif log locally, the log path is the
+			// data-local path. The reader does the right thing regardless of
+			// whether the option is a directory or a file.
+			// verifyEvent defaults it to tenantIdentity for the benefit of the remote reader implementation
+			tenantLogPath := cCtx.String("data-local")
+
+			if tenantLogPath == "" {
+				tenantLogPath = logTenant
+			}
+
 			// configure the cmd massif reader
-			if err = cfgMassifReader(cmd, cCtx); err != nil {
+			cCtx.Set("tenant", logTenant)
+			if err := cfgMassifReader(cmd, cCtx); err != nil {
 				return err
 			}
 
@@ -238,7 +254,7 @@ func NewFindMMREntriesCmd() *cli.Command {
 			leafIndexMatches, entriesConsidered, err := findMMREntries(
 				cmd.log,
 				cmd.massifReader,
-				logTenant,
+				tenantLogPath,
 				massifStartIndex,
 				massifEndIndex,
 				cmd.massifHeight,

--- a/findtrieentries.go
+++ b/findtrieentries.go
@@ -71,7 +71,7 @@ func logIDToLogTenant(logID string) (string, error) {
 func findTrieKeys(
 	log logger.Logger,
 	massifReader MassifReader,
-	logTenant string,
+	tenantLogPath string,
 	massifStartIndex int64,
 	massifEndIndex int64,
 	massifHeight uint8,
@@ -96,10 +96,15 @@ func findTrieKeys(
 			break
 		}
 
-		massifContext, err := massifReader.GetMassif(context.Background(), logTenant, uint64(massifIndex))
+		massifContext, err := massifReader.GetMassif(context.Background(), tenantLogPath, uint64(massifIndex))
 
 		// check if we have reached the last massif
 		if errors.Is(err, massifs.ErrMassifNotFound) {
+			break
+		}
+
+		// check if we have reached the last massif for local log
+		if errors.Is(err, massifs.ErrLogFileMassifNotFound) {
 			break
 		}
 
@@ -238,7 +243,18 @@ func NewFindTrieEntriesCmd() *cli.Command {
 				}
 			}
 
+			// If we are reading the massif log locally, the log path is the
+			// data-local path. The reader does the right thing regardless of
+			// whether the option is a directory or a file.
+			// verifyEvent defaults it to tenantIdentity for the benefit of the remote reader implementation
+			tenantLogPath := cCtx.String("data-local")
+
+			if tenantLogPath == "" {
+				tenantLogPath = logTenant
+			}
+
 			// configure the cmd massif reader
+			cCtx.Set("tenant", logTenant)
 			if err := cfgMassifReader(cmd, cCtx); err != nil {
 				return err
 			}
@@ -265,7 +281,7 @@ func NewFindTrieEntriesCmd() *cli.Command {
 				leafIndexMatches, entriesConsidered, err = findTrieKeys(
 					cmd.log,
 					cmd.massifReader,
-					logTenant,
+					tenantLogPath,
 					massifStartIndex,
 					massifEndIndex,
 					cmd.massifHeight,
@@ -318,7 +334,7 @@ func NewFindTrieEntriesCmd() *cli.Command {
 				leafIndexMatches, entriesConsidered, err = findTrieKeys(
 					cmd.log,
 					cmd.massifReader,
-					logTenant,
+					tenantLogPath,
 					massifStartIndex,
 					massifEndIndex,
 					cmd.massifHeight,

--- a/findtrieentries.go
+++ b/findtrieentries.go
@@ -254,7 +254,10 @@ func NewFindTrieEntriesCmd() *cli.Command {
 			}
 
 			// configure the cmd massif reader
-			cCtx.Set("tenant", logTenant)
+			if err := cCtx.Set("tenant", logTenant); err != nil {
+				return err
+			}
+
 			if err := cfgMassifReader(cmd, cCtx); err != nil {
 				return err
 			}

--- a/tests/systemtest/test.sh
+++ b/tests/systemtest/test.sh
@@ -128,10 +128,30 @@ testVerifySingleEventWithLocalMassifCopy() {
     assertEquals "verifying valid events with a local copy of the massif should result in a 0 exit code" 0 $?
 }
 
-testFindTrieKeySingleEventWithLocalMassifCopy() {
-    # Verify the event and check if the exit code is 0
-    curl -sL $DATATRAILS_URL/archivist/v2/$PUBLIC_EVENT_ID | $VERACITY_INSTALL --data-local $PROD_LOCAL_BLOB_FILE find-trie-entries --log-tenant $PROD_PUBLIC_TENANT_ID --app-id $PUBLIC_EVENT_ID
-    assertEquals "verifying valid events with a local copy of the massif should result in a 0 exit code" 0 $?
+testFindTrieEntrySingleEvent() {
+    # Verify the trie key for the known event is on the log at the correct position.
+    PUBLIC_EVENT_PERMISSIONED_ID=${PUBLIC_EVENT_ID#"public"}
+    output=$(VERACITY_IKWID=true $VERACITY_INSTALL find-trie-entries --log-tenant $PROD_PUBLIC_TENANT_ID --app-id $PUBLIC_EVENT_PERMISSIONED_ID)
+    assertEquals "verifying finding the trie entry of a known public prod event from the datatrails log should match mmr index 663" "matches: [663]" "$output"
+}
+
+testFindTrieEntrySingleEventWithLocalMassifCopy() {
+    # Verify the trie key for the known event is on the log at the correct position for a local log.
+    PUBLIC_EVENT_PERMISSIONED_ID=${PUBLIC_EVENT_ID#"public"}
+    output=$(VERACITY_IKWID=true $VERACITY_INSTALL --data-local $PROD_LOCAL_BLOB_FILE find-trie-entries --log-tenant $PROD_PUBLIC_TENANT_ID --app-id $PUBLIC_EVENT_PERMISSIONED_ID)
+    assertEquals "verifying finding the trie entry of a known public prod event from a local log should match mmr index 663" "matches: [663]" "$output"
+}
+
+testFindMMREntrySingleEvent() {
+    # Verify the mmr entry for the known event is on the log at the correct position.
+    output=$(curl -sL $DATATRAILS_URL/archivist/v2/$PUBLIC_EVENT_ID | VERACITY_IKWID=true $VERACITY_INSTALL find-mmr-entries --log-tenant $PROD_PUBLIC_TENANT_ID)
+    assertEquals "verifying finding the mmr entry of a known public prod event from the datatrails log should match mmr index 663" "matches: [663]" "$output"
+}
+
+testFindMMREntrySingleEventWithLocalMassifCopy() {
+    # Verify the mmr entry for the known event is on the log at the correct position.
+    output=$(curl -sL $DATATRAILS_URL/archivist/v2/$PUBLIC_EVENT_ID | VERACITY_IKWID=true $VERACITY_INSTALL --data-local $PROD_LOCAL_BLOB_FILE find-mmr-entries --log-tenant $PROD_PUBLIC_TENANT_ID)
+    assertEquals "verifying finding the mmr entry of a known public prod event from a local log should match mmr index 663" "matches: [663]" "$output"
 }
 
 testVerifyIncludeLocalErrorForDuplicateMassifs() {

--- a/tests/systemtest/test.sh
+++ b/tests/systemtest/test.sh
@@ -128,6 +128,12 @@ testVerifySingleEventWithLocalMassifCopy() {
     assertEquals "verifying valid events with a local copy of the massif should result in a 0 exit code" 0 $?
 }
 
+testFindTrieKeySingleEventWithLocalMassifCopy() {
+    # Verify the event and check if the exit code is 0
+    curl -sL $DATATRAILS_URL/archivist/v2/$PUBLIC_EVENT_ID | $VERACITY_INSTALL --data-local $PROD_LOCAL_BLOB_FILE find-trie-entries --log-tenant $PROD_PUBLIC_TENANT_ID --app-id $PUBLIC_EVENT_ID
+    assertEquals "verifying valid events with a local copy of the massif should result in a 0 exit code" 0 $?
+}
+
 testVerifyIncludeLocalErrorForDuplicateMassifs() {
     # Verify the event and check if the exit code is 0
     output=$(curl -sL $DATATRAILS_URL/archivist/v2/$PUBLIC_EVENT_ID | $VERACITY_INSTALL --data-local $DUP_DIR/prod-mmr.log --tenant=$PROD_PUBLIC_TENANT_ID verify-included 2>&1)


### PR DESCRIPTION
## Overview
* Support local data logs for the find commands

## Testing

Ran the systemtests:

```
/home/jgough/workspace/veracity/tests/systemtest /home/jgough/workspace/veracity
testVeracityVersion
testVeracityWatchPublicFindsActivity
testVeracityWatchLatestFindsActivity
testVeracityReplicateLogsPublicTenantWatchPipe
testVeracityReplicateLogsPublicTenantWatchLatestFlag
testVerifySingleEvent
testVerifyListEvents
testVerifySingleEventWithLocalMassifCopy
testFindTrieEntrySingleEvent
testFindTrieEntrySingleEventWithLocalMassifCopy
testFindMMREntrySingleEvent
testFindMMREntrySingleEventWithLocalMassifCopy
testVerifyIncludeLocalErrorForDuplicateMassifs
testVerboseOutput
testHelpOutputNoArgs
testValidEventNotinMassif
Expected (hex):
00000000  65 72 72 6f 72 3a 20 74  68 65 20 65 6e 74 72 79  |error: the entry|
00000010  20 69 73 20 6e 6f 74 20  69 6e 20 74 68 65 20 6c  | is not in the l|
00000020  6f 67 2e 20 66 6f 72 20  74 65 6e 61 6e 74 20 74  |og. for tenant t|
00000030  65 6e 61 6e 74 2f 36 65  61 35 63 64 30 30 2d 63  |enant/6ea5cd00-c|
00000040  37 31 31 2d 33 36 34 39  2d 36 39 31 34 2d 37 62  |711-3649-6914-7b|
00000050  31 32 35 39 32 38 62 62  62 34 0a                 |125928bbb4.|
0000005b
Actual (hex):
00000000  65 72 72 6f 72 3a 20 74  68 65 20 65 6e 74 72 79  |error: the entry|
00000010  20 69 73 20 6e 6f 74 20  69 6e 20 74 68 65 20 6c  | is not in the l|
00000020  6f 67 2e 20 66 6f 72 20  74 65 6e 61 6e 74 20 74  |og. for tenant t|
00000030  65 6e 61 6e 74 2f 36 65  61 35 63 64 30 30 2d 63  |enant/6ea5cd00-c|
00000040  37 31 31 2d 33 36 34 39  2d 36 39 31 34 2d 37 62  |711-3649-6914-7b|
00000050  31 32 35 39 32 38 62 62  62 34 0a                 |125928bbb4.|
0000005b
testNon200Response
testMissingMassifFile
testNotBlobFile
testInvalidBlobUrl
Expected (hex):
00000000  65 72 72 6f 72 3a 20 6e  6f 20 6a 73 6f 6e 20 67  |error: no json g|
00000010  69 76 65 6e 0a                                    |iven.|
00000015
Actual (hex):
00000000  65 72 72 6f 72 3a 20 6e  6f 20 6a 73 6f 6e 20 67  |error: no json g|
00000010  69 76 65 6e 0a                                    |iven.|
00000015

Ran 20 tests.

JUnit XML file res.xml was saved.

OK
```