### PR TITLE
fix: verifying local v0 seals against remote v0 seals

### DIFF
--- a/replicatelogs.go
+++ b/replicatelogs.go
@@ -383,7 +383,8 @@ func (v *VerifiedReplica) ReplicateVerifiedUpdates(
 		}
 		state := local.MMRState
 		state.Version = int(massifs.MMRStateVersion1)
-		state.LegacySealRoot = nil
+		// Keep the legacy seal root so that we can verify in the case where the remote is a V0 seal
+		// state.LegacySealRoot = nil
 		state.Peaks = peaks
 		return state, nil
 	}


### PR DESCRIPTION
Local replicas are automatically promoted, after verification, to v1 seals. This is so that over time, we can eventually retire support for v0

In the case where we are promoting the replica, the remote may still be on the v0 format and we missed this case.

AB#10451