### PR TITLE
Update to new event shape

### DIFF
--- a/app/consts_test.go
+++ b/app/consts_test.go
@@ -82,9 +82,11 @@ var (
 			"created_by": "2ef471c2-f997-4503-94c8-60b5c929a3c3",
 			"created_at": 1737045849174,
 			"confirmation_status": "CONFIRMED",
-			"merklelog_commit": {
-				"index": "1",
-				"idtimestamp": "019470003611017900"
+			"event_type": "",
+			"ledger_entry": {
+				"index": "18446744073709551614",
+				"idtimestamp": "019470003611017900",
+				"log_id": "112758ce-a8cb-4924-8df8-fcba1e31f8b0"
 			}
 		}
 	]

--- a/app/eventsv1_test.go
+++ b/app/eventsv1_test.go
@@ -68,7 +68,7 @@ func TestVerifiableEventsV1EventsFromData(t *testing.T) {
 							0x5b, 0x5d, 0x7d,
 						}, // serialized bytes
 					),
-					1, // mmr index
+					18446744073709551614, // mmr index
 				),
 			},
 			err: nil,
@@ -94,7 +94,7 @@ func TestVerifiableEventsV1EventsFromData(t *testing.T) {
 							0x5b, 0x5d, 0x7d,
 						}, // serialized bytes
 					),
-					1, // mmr index
+					18446744073709551614, // mmr index
 				),
 			},
 			err: nil,

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/datatrails/go-datatrails-merklelog/massifs v0.4.0
 	github.com/datatrails/go-datatrails-merklelog/mmr v0.2.0
 	github.com/datatrails/go-datatrails-merklelog/mmrtesting v0.2.0
-	github.com/datatrails/go-datatrails-serialization/eventsv1 v0.0.2
+	github.com/datatrails/go-datatrails-serialization/eventsv1 v0.0.3
 	github.com/datatrails/go-datatrails-simplehash v0.0.5
 	github.com/gosuri/uiprogress v0.0.1
 	github.com/urfave/cli/v2 v2.27.6

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,6 @@ github.com/datatrails/go-datatrails-merklelog/mmr v0.2.0 h1:NUP0OUVixuyWf+Gmi/e3
 github.com/datatrails/go-datatrails-merklelog/mmr v0.2.0/go.mod h1:iLipg39Ce3U68NjXFxjxwxXR9U0T6Dm6pldJA47Lx8s=
 github.com/datatrails/go-datatrails-merklelog/mmrtesting v0.2.0 h1:cv8JincUm3h/4hyVcuofPt5pAtOZ+KYLnsDdvQ3D6Lc=
 github.com/datatrails/go-datatrails-merklelog/mmrtesting v0.2.0/go.mod h1:h8b1O0xAoMv2DsVQuo6vNyM4RLL2DlJCWJqgysX127w=
-github.com/datatrails/go-datatrails-serialization/eventsv1 v0.0.2 h1:yEk+0KvWkn/xYbf3WgdFCAZNkLE4pze9ySqeCr6Pnos=
-github.com/datatrails/go-datatrails-serialization/eventsv1 v0.0.2/go.mod h1:9i6Tip2lIXwSZ3SxP7XEhU2eQ9zkpxhEBmPmlOGqv/8=
 github.com/datatrails/go-datatrails-serialization/eventsv1 v0.0.3 h1:BLHfCXjzXUgr1knXE9XtZC+jNnf2orGEL+BTAWqSyp4=
 github.com/datatrails/go-datatrails-serialization/eventsv1 v0.0.3/go.mod h1:9i6Tip2lIXwSZ3SxP7XEhU2eQ9zkpxhEBmPmlOGqv/8=
 github.com/datatrails/go-datatrails-simplehash v0.0.5 h1:igu4QRYO87RQXrJlqSm3fgMA2Q0F4jglWqBlfvKrXKQ=

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/datatrails/go-datatrails-merklelog/mmrtesting v0.2.0 h1:cv8JincUm3h/4
 github.com/datatrails/go-datatrails-merklelog/mmrtesting v0.2.0/go.mod h1:h8b1O0xAoMv2DsVQuo6vNyM4RLL2DlJCWJqgysX127w=
 github.com/datatrails/go-datatrails-serialization/eventsv1 v0.0.2 h1:yEk+0KvWkn/xYbf3WgdFCAZNkLE4pze9ySqeCr6Pnos=
 github.com/datatrails/go-datatrails-serialization/eventsv1 v0.0.2/go.mod h1:9i6Tip2lIXwSZ3SxP7XEhU2eQ9zkpxhEBmPmlOGqv/8=
+github.com/datatrails/go-datatrails-serialization/eventsv1 v0.0.3 h1:BLHfCXjzXUgr1knXE9XtZC+jNnf2orGEL+BTAWqSyp4=
+github.com/datatrails/go-datatrails-serialization/eventsv1 v0.0.3/go.mod h1:9i6Tip2lIXwSZ3SxP7XEhU2eQ9zkpxhEBmPmlOGqv/8=
 github.com/datatrails/go-datatrails-simplehash v0.0.5 h1:igu4QRYO87RQXrJlqSm3fgMA2Q0F4jglWqBlfvKrXKQ=
 github.com/datatrails/go-datatrails-simplehash v0.0.5/go.mod h1:XuOwViwdL+dyz7fGYIjaByS1ElMFsrVI0goKX0bNimA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/tests/katdata/eventsingles.go
+++ b/tests/katdata/eventsingles.go
@@ -85,9 +85,10 @@ var (
     "created_by": "a3732a3f-1406-45b6-bdce-2976945752fc",
     "created_at": 1738143218368,
     "confirmation_status": "CONFIRMED",
-    "merklelog_commit": {
+    "ledger_entry": {
         "index": "4",
-        "idtimestamp": "0194b168bcde03be00"
+        "idtimestamp": "0194b168bcde03be00",
+        "log_id": "97e90a09-8c56-40df-a4de-42fde462ef6f"
     }
 }`)
 


### PR DESCRIPTION
Update to new event shape

Testing:
updated unit test with new shape
verified inclusion of pre-existing new event (events/0196c725-7c6d-7c8e-ae7a-35b29ad81408) on stage:

```
./veracity --loglevel DEBUG --data-url https://app.soak.stage.datatrails.ai/verifiabledata --tenant tenant/14ec1fdd-f8db-4f91-8f8e-829b311872c5 verify-in
cluded < event.json
verifying for tenant: tenant/14ec1fdd-f8db-4f91-8f8e-829b311872c5
defaulting to the standard container merklelogs
OK|306876 153443|[56f9ba4532670f4eec48a33c917dddd3e834c0eb325ad5d16a727e13954e210c, be5b44c54f0b6a691cb74f2c27cc1acf8e4b30475f0ee46aecffc89ba9c33e4d]
```

system tests pass:

```
Ran 24 tests.

JUnit XML file res.xml was saved.

OK
```


AB#10264